### PR TITLE
Add missing type import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For type signature visit [types.ts](src/types.ts)<br />
 ```typescript
 // Import
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { TradeRouter, PoolService } from '@galacticcouncil/sdk';
+import { TradeRouter, PoolService, PoolType } from '@galacticcouncil/sdk';
 
 // Initialize Polkadot API
 const wsProvider = new WsProvider('wss://rpc.basilisk.cloud');


### PR DESCRIPTION
`PoolType` is referenced below and not imported.