### PR TITLE
add encointer xcm config for KSM teleport

### DIFF
--- a/packages/xcm-cfg/src/chains.ts
+++ b/packages/xcm-cfg/src/chains.ts
@@ -677,6 +677,23 @@ export const basilisk = new Parachain({
   ws: 'wss://rpc.basilisk.cloud',
 });
 
+export const encointer = new Parachain({
+  assetsData: [
+    {
+      asset: ksm,
+      decimals: 12,
+    },
+  ],
+  ecosystem: Ecosystem.Kusama,
+  genesisHash:
+    '0x7dd99936c1e9e6d1ce7d90eb6f33bea8393b4bf87677d675aa63c9cb3e8c5b5b',
+  key: 'encointer',
+  name: 'Encointer',
+  parachainId: 1001,
+  ss58Format: 2,
+  ws: 'wss://kusama.api.encointer.org',
+});
+
 export const karura = new Parachain({
   assetsData: [
     {
@@ -798,6 +815,7 @@ export const tinkernet = new Parachain({
 
 const kusamaChains: AnyChain[] = [
   basilisk,
+  encointer,
   integritee,
   karura,
   kusama,

--- a/packages/xcm-cfg/src/configs/kusama/encointer.ts
+++ b/packages/xcm-cfg/src/configs/kusama/encointer.ts
@@ -1,0 +1,37 @@
+import {
+  BalanceBuilder,
+} from '@moonbeam-network/xcm-builder';
+import { AssetConfig, ChainConfig } from '@moonbeam-network/xcm-config';
+
+import { ksm } from '../../assets';
+import { encointer, kusama} from '../../chains';
+import { ExtrinsicBuilderV2 } from '../../builders';
+
+const xcmDeliveryFeeAmount = 0.0015;
+
+const toKusama: AssetConfig[] = [
+  new AssetConfig({
+    asset: ksm,
+    balance: BalanceBuilder().substrate().system().account(),
+    destination: kusama,
+    destinationFee: {
+      amount: 0.000090049287,
+      asset: ksm,
+      balance: BalanceBuilder().substrate().system().account(),
+    },
+    extrinsic: ExtrinsicBuilderV2()
+      .polkadotXcm()
+      .limitedTeleportAssets(1)
+      .here(),
+    fee: {
+      asset: ksm,
+      balance: BalanceBuilder().substrate().system().account(),
+      xcmDeliveryFeeAmount,
+    },
+  }),
+];
+
+export const encointerConfig = new ChainConfig({
+  assets: [...toKusama],
+  chain: encointer,
+});

--- a/packages/xcm-cfg/src/configs/kusama/index.ts
+++ b/packages/xcm-cfg/src/configs/kusama/index.ts
@@ -2,6 +2,7 @@ import { ChainConfig } from '@moonbeam-network/xcm-config';
 
 import { assetHubConfig } from './assethub';
 import { basiliskConfig } from './basilisk';
+import { encointerConfig } from './encointer';
 import { integriteeConfig } from './integritee';
 import { karuraConfig } from './karura';
 import { kusamaConfig } from './kusama';
@@ -11,6 +12,7 @@ import { robonomicsConfig } from './robonomics';
 export const kusamaChainsConfig: ChainConfig[] = [
   assetHubConfig,
   basiliskConfig,
+  encointerConfig,
   integriteeConfig,
   karuraConfig,
   kusamaConfig,


### PR DESCRIPTION
this is untested. 
As Encointer follows Asset Hub in terms of fees and any relevant constants, this is copy-paste from kusama Asset Hub

This shall support 
* Teleporting KSM between Kusama relay and Encointer
