### PR TITLE
Additional logic for minimum trade size

### DIFF
--- a/packages/sdk/src/pool/omni/OmniPool.ts
+++ b/packages/sdk/src/pool/omni/OmniPool.ts
@@ -95,6 +95,9 @@ export class OmniPool implements Pool {
     const balanceIn = bnum(tokenInMeta.balance);
     const balanceOut = bnum(tokenOutMeta.balance);
 
+    const assetInED = bnum(tokenInMeta.existentialDeposit);
+    const assetOutED = bnum(tokenOutMeta.existentialDeposit);
+
     return {
       assetIn: tokenIn,
       assetOut: tokenOut,
@@ -108,6 +111,8 @@ export class OmniPool implements Pool {
       balanceOut: balanceOut,
       tradeableIn: tokenInMeta.tradeable,
       tradeableOut: tokenOutMeta.tradeable,
+      assetInED,
+      assetOutED,
     } as OmniPoolPair;
   }
 
@@ -133,7 +138,10 @@ export class OmniPool implements Pool {
       errors.push(PoolError.TradeNotAllowed);
     }
 
-    if (amountOut.isLessThan(this.minTradingLimit)) {
+    if (
+      amountOut.isLessThan(this.minTradingLimit) ||
+      calculatedIn.isLessThan(poolPair.assetInED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 
@@ -175,7 +183,10 @@ export class OmniPool implements Pool {
       errors.push(PoolError.TradeNotAllowed);
     }
 
-    if (amountIn.isLessThan(this.minTradingLimit)) {
+    if (
+      amountIn.isLessThan(this.minTradingLimit) ||
+      calculatedOut.isLessThan(poolPair.assetOutED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 

--- a/packages/sdk/src/pool/stable/StableSwap.ts
+++ b/packages/sdk/src/pool/stable/StableSwap.ts
@@ -97,6 +97,9 @@ export class StableSwap implements Pool {
     const balanceIn = bnum(tokenInMeta.balance);
     const balanceOut = bnum(tokenOutMeta.balance);
 
+    const assetInED = bnum(tokenInMeta.existentialDeposit);
+    const assetOutED = bnum(tokenOutMeta.existentialDeposit);
+
     return {
       assetIn: tokenIn,
       assetOut: tokenOut,
@@ -108,6 +111,8 @@ export class StableSwap implements Pool {
         this.id === tokenIn ? TRADEABLE_DEFAULT : tokenInMeta.tradeable,
       tradeableOut:
         this.id === tokenOut ? TRADEABLE_DEFAULT : tokenOutMeta.tradeable,
+      assetInED,
+      assetOutED,
     } as StableSwapPair;
   }
 
@@ -128,7 +133,10 @@ export class StableSwap implements Pool {
       errors.push(PoolError.TradeNotAllowed);
     }
 
-    if (amountOut.isLessThan(this.minTradingLimit)) {
+    if (
+      amountOut.isLessThan(this.minTradingLimit) ||
+      calculatedIn.isLessThan(poolPair.assetInED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 
@@ -158,7 +166,10 @@ export class StableSwap implements Pool {
       errors.push(PoolError.TradeNotAllowed);
     }
 
-    if (amountIn.isLessThan(this.minTradingLimit)) {
+    if (
+      amountIn.isLessThan(this.minTradingLimit) ||
+      calculatedOut.isLessThan(poolPair.assetOutED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 

--- a/packages/sdk/src/pool/xyk/XykPool.ts
+++ b/packages/sdk/src/pool/xyk/XykPool.ts
@@ -67,6 +67,9 @@ export class XykPool implements Pool {
     const balanceIn = bnum(tokenInMeta.balance);
     const balanceOut = bnum(tokenOutMeta.balance);
 
+    const assetInED = bnum(tokenInMeta.existentialDeposit);
+    const assetOutED = bnum(tokenOutMeta.existentialDeposit);
+
     return {
       assetIn: tokenIn,
       assetOut: tokenOut,
@@ -74,6 +77,8 @@ export class XykPool implements Pool {
       decimalsOut: tokenOutMeta.decimals,
       balanceIn: balanceIn,
       balanceOut: balanceOut,
+      assetInED,
+      assetOutED,
     } as PoolPair;
   }
 
@@ -90,7 +95,10 @@ export class XykPool implements Pool {
 
     const errors: PoolError[] = [];
 
-    if (amountOut.isLessThan(this.minTradingLimit)) {
+    if (
+      amountOut.isLessThan(this.minTradingLimit) ||
+      calculatedIn.isLessThan(poolPair.assetInED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 
@@ -126,7 +134,10 @@ export class XykPool implements Pool {
 
     const errors: PoolError[] = [];
 
-    if (amountIn.isLessThan(this.minTradingLimit)) {
+    if (
+      amountIn.isLessThan(this.minTradingLimit) ||
+      calculatedOut.isLessThan(poolPair.assetOutED)
+    ) {
       errors.push(PoolError.InsufficientTradingAmount);
     }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -22,6 +22,8 @@ export interface PoolPair {
   decimalsOut: number;
   balanceIn: BigNumber;
   balanceOut: BigNumber;
+  assetInED: BigNumber;
+  assetOutED: BigNumber;
 }
 
 export type PoolBase = {


### PR DESCRIPTION
On swap screen, currently we are comparing minimum trade size agains constant omnipool.minimumTradingLimit

We should add new condition that user will be only able to swap if trade size is > omnipool.minimumTradingLimit AND trade size > selected asset ED (asset which user will get is assetOut)

If both conditions are not met, we can still use current notification that trade size is too small