### PR TITLE
chore: update Unique ws endpoint to geo load balancer

### DIFF
--- a/packages/xcm-cfg/src/chains/polkadot/unique.ts
+++ b/packages/xcm-cfg/src/chains/polkadot/unique.ts
@@ -20,5 +20,5 @@ export const unique = new Parachain({
   name: 'Unique network',
   parachainId: 2037,
   ss58Format: 7391,
-  ws: 'wss://unique-rpc.dwellir.com',
+  ws: 'wss://ws.unique.network',
 });


### PR DESCRIPTION
The previous WebSocket endpoint (wss://unique-rpc.dwellir.com) no longer works and may be deprecated by the Dwellir team. As a result, the bridge with Unique Network is stuck in a "connecting" state. Updated to Unique Network's official geo load-balanced RPC.