### PR TITLE
Add Snowbridge assets AH routes

### DIFF
--- a/.changeset/fuzzy-pots-make.md
+++ b/.changeset/fuzzy-pots-make.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/xcm-cfg': minor
+---
+
+Add new SB assets

--- a/packages/xcm-cfg/src/chains/polkadot/assethub.ts
+++ b/packages/xcm-cfg/src/chains/polkadot/assethub.ts
@@ -4,7 +4,7 @@ import {
   ParachainParams,
 } from '@galacticcouncil/xcm-core';
 
-import { ded, dot, dota, ksm, myth, pink, usdc, usdt, wud } from '../../assets';
+import { aave, ded, dot, dota, eth, ksm, ldo, link, myth, pink, sky, tbtc, usdc, usdc_eth, usdt, usdt_eth, wud } from '../../assets';
 
 const config = {
   assetsData: [
@@ -153,6 +153,198 @@ const config = {
           X1: [
             {
               GlobalConsensus: 'Kusama',
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: eth,
+      decimals: 18,
+      min: 0.0000055,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X1: {
+            GlobalConsensus: {
+              Ethereum: {
+                chainId: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      asset: usdc_eth,
+      decimals: 6,
+      min: 0.01,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: usdt_eth,
+      decimals: 6,
+      min: 0.01,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: tbtc,
+      decimals: 18,
+      min: 0.00000023,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x18084fba666a33d37592fa2633fd49a74dd93a88',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: aave,
+      decimals: 18,
+      min: 0.00006,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: link,
+      decimals: 18,
+      min: 0.001,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x514910771af9ca656af840dff83e8264ecf986ca',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: sky,
+      decimals: 18,
+      min: 0.52,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x56072c95faa701256059aa122697b133aded9279',
+              },
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: ldo,
+      decimals: 18,
+      min: 0.013,
+      xcmLocation: {
+        parents: 2,
+        interior: {
+          X2: [
+            {
+              GlobalConsensus: {
+                Ethereum: {
+                  chainId: 1,
+                },
+              },
+            },
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x5a98fcbea516cf06857215779fd812ca3bef1b32',
+              },
             },
           ],
         },

--- a/packages/xcm-cfg/src/configs/polkadot/assethub/index.ts
+++ b/packages/xcm-cfg/src/configs/polkadot/assethub/index.ts
@@ -1,14 +1,22 @@
 import { AssetRoute, ChainRoutes } from '@galacticcouncil/xcm-core';
 
 import {
+  aave,
   ded,
   dot,
   dota,
+  eth,
   ksm,
+  ldo,
+  link,
   myth,
   pink,
+  sky,
+  tbtc,
   usdc,
+  usdc_eth,
   usdt,
+  usdt_eth,
   wud,
 } from '../../../assets';
 import {
@@ -33,6 +41,7 @@ import {
   toParaStablesWithSwapTemplate,
   toHydrationExtTemplate,
   toMoonbeamExtTemplate,
+  toHydrationForeignAssetTemplate,
   extraFee,
 } from './templates';
 
@@ -61,31 +70,15 @@ const toHydration: AssetRoute[] = [
     },
     extrinsic: ExtrinsicBuilder().polkadotXcm().limitedReserveTransferAssets(),
   }),
-  new AssetRoute({
-    source: {
-      asset: ksm,
-      balance: BalanceBuilder().substrate().foreignAssets().account(),
-      fee: {
-        asset: dot,
-        balance: BalanceBuilder().substrate().system().account(),
-        extra: extraFee,
-      },
-      destinationFee: {
-        balance: BalanceBuilder().substrate().foreignAssets().account(),
-      },
-    },
-    destination: {
-      chain: hydration,
-      asset: ksm,
-      fee: {
-        amount: 0.0001,
-        asset: ksm,
-      },
-    },
-    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
-      transferType: XcmTransferType.LocalReserve,
-    }),
-  }),
+  toHydrationForeignAssetTemplate(ksm, XcmTransferType.LocalReserve, 0.0001),
+  toHydrationForeignAssetTemplate(eth, XcmTransferType.DestinationReserve, 0.0000055),
+  toHydrationForeignAssetTemplate(usdc_eth, XcmTransferType.DestinationReserve, 0.01),
+  toHydrationForeignAssetTemplate(usdt_eth, XcmTransferType.DestinationReserve, 0.01),
+  toHydrationForeignAssetTemplate(tbtc, XcmTransferType.DestinationReserve, 0.00000023),
+  toHydrationForeignAssetTemplate(aave, XcmTransferType.DestinationReserve, 0.00006),
+  toHydrationForeignAssetTemplate(link, XcmTransferType.DestinationReserve, 0.001),
+  toHydrationForeignAssetTemplate(sky, XcmTransferType.DestinationReserve, 0.52),
+  toHydrationForeignAssetTemplate(ldo, XcmTransferType.DestinationReserve, 0.013),
   toParaStablesTemplate(usdt, hydration, 0.02),
   toParaStablesTemplate(usdc, hydration, 0.02),
   toHydrationExtTemplate(pink),

--- a/packages/xcm-cfg/src/configs/polkadot/assethub/templates.ts
+++ b/packages/xcm-cfg/src/configs/polkadot/assethub/templates.ts
@@ -5,12 +5,13 @@ import {
   ExtrinsicConfigBuilderParams,
 } from '@galacticcouncil/xcm-core';
 
-import { dot, usdt } from '../../../assets';
+import { aave, dot, eth, ksm, ldo, link, sky, tbtc, usdc_eth, usdt, usdt_eth } from '../../../assets';
 import {
   AssetMinBuilder,
   BalanceBuilder,
   ExtrinsicBuilder,
   ExtrinsicDecorator,
+  XcmTransferType,
 } from '../../../builders';
 import { hydration, moonbeam } from '../../../chains';
 
@@ -141,4 +142,36 @@ export function toHydrationExtTemplate(asset: Asset): AssetRoute {
 
 export function toMoonbeamExtTemplate(asset: Asset): AssetRoute {
   return toParaExtTemplate(asset, moonbeam, 0.25);
+}
+
+export function toHydrationForeignAssetTemplate(
+  asset: Asset,
+  transferType: XcmTransferType,
+  destinationFee: number
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: asset,
+      balance: BalanceBuilder().substrate().foreignAssets().account(),
+      fee: {
+        asset: dot,
+        balance: BalanceBuilder().substrate().system().account(),
+        extra: extraFee,
+      },
+      destinationFee: {
+        balance: BalanceBuilder().substrate().foreignAssets().account(),
+      },
+    },
+    destination: {
+      chain: hydration,
+      asset: asset,
+      fee: {
+        amount: destinationFee,
+        asset: asset,
+      },
+    },
+    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
+      transferType: transferType,
+    }),
+  });
 }

--- a/packages/xcm-cfg/src/configs/polkadot/hydration/index.ts
+++ b/packages/xcm-cfg/src/configs/polkadot/hydration/index.ts
@@ -96,6 +96,7 @@ import {
   toSolanaViaWormholeTemplate,
   toZeitgeistErc20Template,
   toTransferTemplate,
+  toAssetHubForeignAssetTemplate,
 } from './templates';
 
 const toAcala: AssetRoute[] = [
@@ -107,48 +108,16 @@ const toAcala: AssetRoute[] = [
 ];
 
 const toAssetHub: AssetRoute[] = [
-  new AssetRoute({
-    source: {
-      asset: dot,
-      balance: balance(),
-      fee: fee(),
-      destinationFee: {
-        balance: balance(),
-      },
-    },
-    destination: {
-      chain: assetHub,
-      asset: dot,
-      fee: {
-        amount: 0.19,
-        asset: dot,
-      },
-    },
-    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
-      transferType: XcmTransferType.DestinationReserve,
-    }),
-  }),
-  new AssetRoute({
-    source: {
-      asset: ksm,
-      balance: balance(),
-      fee: fee(),
-      destinationFee: {
-        balance: balance(),
-      },
-    },
-    destination: {
-      chain: assetHub,
-      asset: ksm,
-      fee: {
-        amount: 0.05,
-        asset: ksm,
-      },
-    },
-    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
-      transferType: XcmTransferType.DestinationReserve,
-    }),
-  }),
+  toAssetHubForeignAssetTemplate(dot, XcmTransferType.DestinationReserve, 0.19),
+  toAssetHubForeignAssetTemplate(ksm, XcmTransferType.DestinationReserve, 0.05),
+  toAssetHubForeignAssetTemplate(eth, XcmTransferType.LocalReserve, 0.0000055),
+  toAssetHubForeignAssetTemplate(usdc_eth, XcmTransferType.LocalReserve, 0.01),
+  toAssetHubForeignAssetTemplate(usdt_eth, XcmTransferType.LocalReserve, 0.01),
+  toAssetHubForeignAssetTemplate(tbtc, XcmTransferType.LocalReserve, 0.00000023),
+  toAssetHubForeignAssetTemplate(aave, XcmTransferType.LocalReserve, 0.00006),
+  toAssetHubForeignAssetTemplate(link, XcmTransferType.LocalReserve, 0.001),
+  toAssetHubForeignAssetTemplate(sky, XcmTransferType.LocalReserve, 0.52),
+  toAssetHubForeignAssetTemplate(ldo, XcmTransferType.LocalReserve, 0.013),
   new AssetRoute({
     source: {
       asset: usdt,

--- a/packages/xcm-cfg/src/configs/polkadot/hydration/templates.ts
+++ b/packages/xcm-cfg/src/configs/polkadot/hydration/templates.ts
@@ -342,3 +342,31 @@ export function toSolanaViaWormholeTemplate(
     tags: [Tag.Mrl, Tag.Wormhole],
   });
 }
+
+export function toAssetHubForeignAssetTemplate(
+  asset: Asset,
+  transferType: XcmTransferType,
+  destinationFee: number
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: asset,
+      balance: balance(),
+      fee: fee(),
+      destinationFee: {
+        balance: balance(),
+      },
+    },
+    destination: {
+      chain: assetHub,
+      asset: asset,
+      fee: {
+        amount: destinationFee,
+        asset: asset,
+      },
+    },
+    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
+      transferType: transferType,
+    }),
+  });
+}


### PR DESCRIPTION
- ETH (34)
- USDC (1,000,766)
- USDT (1,000,767)
- tBTC (1,000,765)
- AAVE (1,000,624)
- LINK (1,000,794)
- SKY (1,000,795)
- LDO (1,000,796)