### PR TITLE
Align polkadot peer dependency versions

### DIFF
--- a/.changeset/align-polkadot-peers.md
+++ b/.changeset/align-polkadot-peers.md
@@ -1,0 +1,6 @@
+---
+'@galacticcouncil/sdk': patch
+'@galacticcouncil/xcm-core': patch
+---
+
+Align polkadot peer dependency versions with @polkadot/api@16.4.8 requirements

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
     "@polkadot/api-augment": "^16.4.8",
     "@polkadot/api-base": "^16.4.8",
     "@polkadot/api-derive": "^16.4.8",
-    "@polkadot/keyring": "^13.5.6",
+    "@polkadot/keyring": "^14.0.1",
     "@polkadot/rpc-augment": "^16.4.8",
     "@polkadot/rpc-core": "^16.4.8",
     "@polkadot/rpc-provider": "^16.4.8",
@@ -58,8 +58,8 @@
     "@polkadot/types-codec": "^16.4.8",
     "@polkadot/types-create": "^16.4.8",
     "@polkadot/types-known": "^16.4.8",
-    "@polkadot/util": "^13.5.6",
-    "@polkadot/util-crypto": "^13.5.6",
+    "@polkadot/util": "^14.0.1",
+    "@polkadot/util-crypto": "^14.0.1",
     "viem": "^2.38.3"
   }
 }

--- a/packages/xcm-core/package.json
+++ b/packages/xcm-core/package.json
@@ -56,7 +56,7 @@
     "@polkadot/api": "^16.4.8",
     "@polkadot/api-augment": "^16.4.8",
     "@polkadot/types": "^16.4.8",
-    "@polkadot/util-crypto": "^13.5.6",
+    "@polkadot/util-crypto": "^14.0.1",
     "viem": "^2.38.3"
   }
 }


### PR DESCRIPTION
## Summary

Updates outdated peer dependencies to match `@polkadot/api@16.4.8` requirements.

## Problem

`@polkadot/api@16.4.8` requires `@polkadot/keyring@^14.0.1`, `@polkadot/util@^14.0.1`, and `@polkadot/util-crypto@^14.0.1`, but the SDK declares peer dependencies on the 13.5.x versions. This causes npm to fail dependency resolution without `--legacy-peer-deps`.
