### PR TITLE
docs: fix typo in math-hsm README - change LBP to HSM

### DIFF
--- a/packages/math-hsm/README.md
+++ b/packages/math-hsm/README.md
@@ -1,4 +1,4 @@
-# LBP math
+# HSM math
 
 [![npm version](https://img.shields.io/npm/v/@galacticcouncil/math-hsm.svg)](https://www.npmjs.com/package/@galacticcouncil/math-hsm)
 


### PR DESCRIPTION
## Fix typo in math-hsm README

### Description

This PR fixes a typo in the `packages/math-hsm/README.md` file where the heading incorrectly said "LBP math" instead of "HSM math".

### Changes

- Changed `# LBP math` to `# HSM math` in the math-hsm package README

### Before
```md
# LBP math