### PR TITLE
Added min liquidity threshold

### DIFF
--- a/.changeset/rich-tires-enter.md
+++ b/.changeset/rich-tires-enter.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/sdk-next': minor
+---
+
+Added minimum liquidty threshold in pool

--- a/packages/sdk-next/src/sor/Router.spec.ts
+++ b/packages/sdk-next/src/sor/Router.spec.ts
@@ -55,6 +55,6 @@ describe('Router with mocked pool ctx', () => {
 
   it('Should return all tradeable assets', async () => {
     const result = await sor.getTradeableAssets();
-    expect(result).toStrictEqual([0, 1, 2]);
+    expect(result).toStrictEqual([0, 1, 2, 3, 222]);
   });
 });

--- a/packages/sdk-next/src/sor/TradeRouter.spec.ts
+++ b/packages/sdk-next/src/sor/TradeRouter.spec.ts
@@ -59,3 +59,18 @@ describe('TradeRouter with mocked pool ctx', () => {
     expect(buy.amountIn).toStrictEqual(lastRoute.amountIn);
   });
 });
+
+describe('TradeRouter spot-price liquidity threshold', () => {
+  let ctx: IPoolCtxProvider;
+  let sor: TradeRouter;
+
+  beforeEach(() => {
+    ctx = new MockCtxProvider();
+    sor = new TradeRouter(ctx);
+  });
+
+  it('suppresses spot price when assetIn depth is below MIN_LIQUIDITY', async () => {
+    const price = await sor.getSpotPrice(3, 222);
+    expect(price).toBeUndefined();
+  });
+});

--- a/packages/sdk-next/src/sor/TradeRouter.ts
+++ b/packages/sdk-next/src/sor/TradeRouter.ts
@@ -23,6 +23,17 @@ type Ctx = {
   poolsMap: Map<string, Pool>;
 };
 
+// Reference stables used to value `assetIn` depth for the liquidity threshold.
+const REFERENCE_STABLES: Set<number> = new Set([
+  222, // HOLLAR
+  10, // USDT
+  21, // USDC
+]);
+
+// Minimum assetIn depth required for `getSpotPrice` to return a price,
+// 10,000 HOLLAR.
+const MIN_LIQUIDITY: bigint = 10_000n * 10n ** 18n;
+
 export class TradeRouter extends Router {
   private readonly mlr: Map<string, Hop[]>;
 
@@ -495,29 +506,95 @@ export class TradeRouter extends Router {
   }
 
   /**
-   * Calculate and return best possible spot price for assetIn > assetOut pair
+   * Calculate and return best possible spot price for assetIn > assetOut pair.
+   *
+   * Returns `undefined` when the depth of `assetIn` — is below `MIN_LIQUIDITY`.
    *
    * @param {number} assetIn - asset in
    * @param {number} assetOut - asset out
    * @return spot price of given asset pair, or undefined if trade not supported
+   *         or `assetIn` depth is below `MIN_LIQUIDITY`
    */
   async getSpotPrice(
     assetIn: number,
     assetOut: number
   ): Promise<Amount | undefined> {
-    return this.withCtx(assetIn, assetOut, async (ctx) => {
-      const { pools, poolsMap } = ctx;
+    try {
+      const route = await this.getMostLiquidRoute(assetIn, assetOut);
+      const spot = await this.withCtx(assetIn, assetOut, ({ poolsMap }) =>
+        this.computeSpotPrice(route, poolsMap)
+      );
 
-      const routeKey = this.buildRouteKey(assetIn, assetOut, pools);
-      let route = this.mlr.get(routeKey);
-      if (!route) {
-        route = await this.calculateMostLiquidRoute(assetIn, assetOut, ctx);
+      const depth = await this.depthInUsd(assetIn);
+      if (depth !== undefined && depth < MIN_LIQUIDITY) return undefined;
+
+      return spot;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async computeSpotPrice(
+    route: Hop[],
+    poolsMap: Map<string, Pool>
+  ): Promise<Amount> {
+    const swaps = await this.toSellSwaps('1', route, poolsMap);
+    return { amount: this.getSellSpot(swaps), decimals: RUNTIME_DECIMALS };
+  }
+
+  /**
+   * Depth of `assetId` in 18-decimal USD-equivalent units —
+   *   max single-pool balance × spot[assetId → first reachable reference].
+   */
+  private async depthInUsd(assetId: number): Promise<bigint | undefined> {
+    const pools = await this.getPools();
+
+    const isAaveAtoken = pools.some(
+      (p) => p.type === PoolType.Aave && p.tokens[1]?.id === assetId
+    );
+    if (isAaveAtoken) return undefined;
+
+    const { maxBalance, decimals } = this.assetMetrics(assetId, pools);
+    if (decimals === undefined) return undefined;
+    if (maxBalance === 0n) return 0n;
+
+    if (REFERENCE_STABLES.has(assetId)) {
+      return calc.mulScaled(maxBalance, 1n, decimals, 0, RUNTIME_DECIMALS);
+    }
+
+    for (const ref of REFERENCE_STABLES) {
+      try {
+        const route = await this.getMostLiquidRoute(assetId, ref);
+        const spot = await this.withCtx(assetId, ref, ({ poolsMap }) =>
+          this.computeSpotPrice(route, poolsMap)
+        );
+        return calc.mulSpot(
+          maxBalance,
+          spot.amount,
+          decimals,
+          RUNTIME_DECIMALS
+        );
+      } catch {
+        continue;
       }
+    }
+    return undefined;
+  }
 
-      const swaps = await this.toSellSwaps('1', route, poolsMap);
-      const spotPrice = this.getSellSpot(swaps);
-      return { amount: spotPrice, decimals: RUNTIME_DECIMALS };
-    }).catch(() => undefined);
+  private assetMetrics(
+    assetId: number,
+    pools: PoolBase[]
+  ): { maxBalance: bigint; decimals: number | undefined } {
+    let maxBalance = 0n;
+    let decimals: number | undefined;
+    for (const pool of pools) {
+      for (const token of pool.tokens) {
+        if (token.id !== assetId) continue;
+        if (token.balance > maxBalance) maxBalance = token.balance;
+        if (decimals === undefined) decimals = token.decimals;
+      }
+    }
+    return { maxBalance, decimals };
   }
 
   /**

--- a/packages/sdk-next/src/sor/route/graph.spec.ts
+++ b/packages/sdk-next/src/sor/route/graph.spec.ts
@@ -25,6 +25,14 @@ describe('Suggester graph for XYK pool', () => {
       '2': [
         ['bXjT2D2cuxUuP2JzddMxYusg4cKo3wENje5Xdk3jbNwtRvStq', 2, 0],
         ['bXi1mHNp4jSRUNXuX3sY1fjCF9Um2EezkpzkFmQuLHaChdPM3', 2, 1],
+        ['bXjHOLLARP1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 2, 222],
+        ['bXjHOLLARP2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 2, 3],
+      ],
+      '222': [
+        ['bXjHOLLARP1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 222, 2],
+      ],
+      '3': [
+        ['bXjHOLLARP2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 3, 2],
       ],
     });
   });

--- a/packages/sdk-next/test/data/xykPools.ts
+++ b/packages/sdk-next/test/data/xykPools.ts
@@ -74,4 +74,55 @@ export const xykPools = [
       },
     ],
   },
+  // HOLLAR pool — gives assets {0,1,2} a route to a reference asset so the
+  // liquidity gate can resolve their depth. Balanced so existing-asset depth
+  // sits above MIN_LIQUIDITY
+  {
+    address: 'bXjHOLLARP1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    type: PoolType.XYK,
+    maxInRatio: 3000n,
+    maxOutRatio: 3000n,
+    minTradingLimit: 1000n,
+    tokens: [
+      {
+        id: 2,
+        balance: 1000000000000000n,
+        decimals: 12,
+        existentialDeposit: 1000n,
+        type: token,
+      },
+      {
+        id: 222,
+        balance: 1000000000000000n,
+        decimals: 12,
+        existentialDeposit: 1000n,
+        type: token,
+      },
+    ],
+  },
+  // Thin pool for asset 3 — routable to HOLLAR via asset 2 but with a max
+  // balance tiny enough that asset-3 depth falls below MIN_LIQUIDITY.
+  {
+    address: 'bXjHOLLARP2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    type: PoolType.XYK,
+    maxInRatio: 3000n,
+    maxOutRatio: 3000n,
+    minTradingLimit: 1000n,
+    tokens: [
+      {
+        id: 3,
+        balance: 100n,
+        decimals: 12,
+        existentialDeposit: 1000n,
+        type: token,
+      },
+      {
+        id: 2,
+        balance: 100n,
+        decimals: 12,
+        existentialDeposit: 1000n,
+        type: token,
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Adds a liquidity gate to TradeRouter.getSpotPrice so it returns undefined when assetIn is too thinly capitalized to be meaningfully priced. Depth is measured as maxSinglePoolBalance(assetIn) × spot[assetIn → first reachable reference stable] valued in 18-decimal units, with HOLLAR (222), USDT (10), USDC (21) as the reference set (HOLLAR first). Threshold is 10,000 HOLLAR-equivalent.

The pools with less than 10k hollar value 
<img width="429" height="174" alt="image" src="https://github.com/user-attachments/assets/04fa7680-7be3-47f5-a68b-1b0d8f920b45" />

Changes: 

- getSpotPrice rewritten to compute spot, then check depth via new private depthInUsd helper.
- Spot computation factored into computeSpotPrice so it's reusable from the depth path.
- assetMetrics helper extracts max balance and decimals across pools in one pass.
- Test fixtures: added 2↔222 (thick) and 3↔2 (thin) XYK pools; new spec asserts getSpotPrice(3, 222) is suppressed; existing graph/router specs updated for the new edges.

Issue #312 