### PR TITLE
Wormhole rate limits

### DIFF
--- a/.changeset/dull-news-warn.md
+++ b/.changeset/dull-news-warn.md
@@ -1,0 +1,6 @@
+---
+'@galacticcouncil/xc-sdk': minor
+'@galacticcouncil/xc': minor
+---
+
+Added wormhole rate limits check

--- a/examples/xc-transfer/esbuild.dev.mjs
+++ b/examples/xc-transfer/esbuild.dev.mjs
@@ -10,6 +10,7 @@ const options = {
     'src/redeem.ts',
     'src/scan.ts',
     'src/circuitbreaker.ts',
+    'src/wormhole-ratelimit.ts',
   ],
   bundle: true,
   format: 'esm',

--- a/examples/xc-transfer/public/wormhole-ratelimit/index.html
+++ b/examples/xc-transfer/public/wormhole-ratelimit/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>XC Transfer Example - Wormhole Rate Limits</title>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <p>Open the browser console to see Wormhole Governor rate-limit state.</p>
+    <script>
+      new EventSource('/esbuild').addEventListener('change', () =>
+        location.reload()
+      );
+    </script>
+    <script type="module" src="/out/wormhole-ratelimit.js"></script>
+  </body>
+</html>

--- a/examples/xc-transfer/src/wormhole-ratelimit.ts
+++ b/examples/xc-transfer/src/wormhole-ratelimit.ts
@@ -1,0 +1,85 @@
+import { Wormhole } from '@galacticcouncil/xc-core';
+
+import { ctx } from './setup';
+
+function pct(used: number, limit: number): string {
+  if (limit === 0) return '–';
+  return `${((used / limit) * 100).toFixed(2)}%`;
+}
+
+function usd(value: number): string {
+  return `$${value.toLocaleString('en-US')}`;
+}
+
+const { config, wormhole } = ctx;
+const { governor } = wormhole;
+
+console.group('Wormhole Governor Rate Limits');
+
+// Wormhole chains present in the config, de-duplicated by wormhole id.
+const wormholeIds = new Map<number, string>();
+for (const chain of config.chains.values()) {
+  if (Wormhole.isKnown(chain)) {
+    wormholeIds.set(Wormhole.fromChain(chain).getWormholeId(), chain.name);
+  }
+}
+
+const rows: Record<string, string | number>[] = [];
+for (const [wormholeId, name] of wormholeIds) {
+  const state = await governor.getWormholeRateLimit(wormholeId);
+
+  rows.push({
+    chain: `${name} (wh:${wormholeId})`,
+    status: !state.configured
+      ? 'not governed'
+      : state.availableNotional <= 0
+        ? 'LOCKDOWN'
+        : 'Active',
+    available: state.configured
+      ? `${usd(state.availableNotional)} / ${usd(state.notionalLimit)}`
+      : '–',
+    utilised: state.configured
+      ? pct(state.notionalLimit - state.availableNotional, state.notionalLimit)
+      : '–',
+    bigTx: state.configured ? usd(state.maxTransactionSize) : '–',
+    enqueued: state.enqueuedCount,
+  });
+}
+
+console.table(rows);
+console.groupEnd();
+
+// Resolve each configured asset to its Governor price using the SAME origin
+// probe as WormholeRateLimitValidation — verifies origin keys match the
+// Governor token list.
+console.group('Configured Asset → Governor Price');
+
+const prices = await governor.getTokenPrices();
+const priceKey = (id: number, addr: string) => `${id}:${addr.toLowerCase()}`;
+
+const tokenRows: Record<string, string | number>[] = [];
+for (const asset of config.assets.values()) {
+  for (const chain of config.chains.values()) {
+    if (!Wormhole.isKnown(chain) || !chain.getAsset(asset.key)) continue;
+
+    const wormhole = Wormhole.fromChain(chain);
+    let originAddress: string;
+    try {
+      originAddress = wormhole.normalizeAddress(String(chain.getAssetId(asset)));
+    } catch {
+      continue;
+    }
+
+    const price = prices.get(priceKey(wormhole.getWormholeId(), originAddress));
+    tokenRows.push({
+      asset: asset.originSymbol,
+      chain: `${chain.name} (wh:${wormhole.getWormholeId()})`,
+      originAddress,
+      governed: price !== undefined ? 'yes' : 'no',
+      price: price !== undefined ? `$${price}` : '–',
+    });
+  }
+}
+
+console.table(tokenRows);
+console.groupEnd();

--- a/packages/xc-sdk/src/clients/WormholeGovernor.ts
+++ b/packages/xc-sdk/src/clients/WormholeGovernor.ts
@@ -1,0 +1,145 @@
+const DEFAULT_URL = 'https://api.wormholescan.io';
+
+export interface GovernorChainLimit {
+  chainId: number;
+  availableNotional: number;
+  notionalLimit: number;
+  maxTransactionSize: number;
+}
+
+export interface GovernorTokenPrice {
+  originChainId: number;
+  originAddress: string;
+  price: number;
+}
+
+export interface GovernorEnqueuedVaa {
+  sequence: number;
+  emitterAddress: string;
+  notionalValue: number;
+  txHash: string;
+}
+
+export interface WormholeRateLimit {
+  configured: boolean;
+  notionalLimit: number;
+  availableNotional: number;
+  maxTransactionSize: number;
+  enqueued: boolean;
+  enqueuedCount: number;
+}
+
+export class WormholeGovernor {
+  private _baseUrl: string;
+  private _prices?: Promise<Map<string, number>>;
+
+  public constructor(baseUrl?: string) {
+    this._baseUrl = baseUrl || DEFAULT_URL;
+  }
+
+  private async fetchData<T>(api: string): Promise<T> {
+    const resp = await fetch([this._baseUrl, api].join(''));
+    if (!resp.ok) {
+      throw new Error(
+        `Wormhole Governor request failed: ${resp.status} ${api}`
+      );
+    }
+    const json = await resp.json();
+    return json.data as T;
+  }
+
+  async getRateLimits(): Promise<GovernorChainLimit[]> {
+    return this.fetchData('/api/v1/governor/limit');
+  }
+
+  async getConfig(): Promise<{ tokens: GovernorTokenPrice[] }[]> {
+    return this.fetchData('/api/v1/governor/config');
+  }
+
+  async getEnqueuedVaas(): Promise<
+    { chainId: number; enqueuedVaas: GovernorEnqueuedVaa[] }[]
+  > {
+    return this.fetchData('/api/v1/governor/enqueued_vaas');
+  }
+
+  private priceKey(originChainId: number, originAddress: string): string {
+    return `${originChainId}:${originAddress.toLowerCase()}`;
+  }
+
+  async getTokenPrices(): Promise<Map<string, number>> {
+    if (!this._prices) {
+      this._prices = this.getConfig()
+        .then((config) => {
+          const prices = new Map<string, number>();
+          const tokens = config[0]?.tokens ?? [];
+          for (const t of tokens) {
+            prices.set(
+              this.priceKey(t.originChainId, t.originAddress),
+              t.price
+            );
+          }
+          return prices;
+        })
+        .catch((e) => {
+          this._prices = undefined;
+          throw e;
+        });
+    }
+    return this._prices;
+  }
+
+  async getWormholeRateLimit(
+    wormholeChainId: number
+  ): Promise<WormholeRateLimit> {
+    const [limits, enqueued] = await Promise.all([
+      this.getRateLimits(),
+      this.getEnqueuedVaas(),
+    ]);
+
+    const limit = limits.find((l) => l.chainId === wormholeChainId);
+    const enqueuedCount =
+      enqueued.find((e) => e.chainId === wormholeChainId)?.enqueuedVaas
+        ?.length ?? 0;
+
+    if (!limit) {
+      return {
+        configured: false,
+        notionalLimit: 0,
+        availableNotional: 0,
+        maxTransactionSize: 0,
+        enqueued: enqueuedCount > 0,
+        enqueuedCount,
+      };
+    }
+
+    return {
+      configured: true,
+      notionalLimit: limit.notionalLimit,
+      availableNotional: limit.availableNotional,
+      maxTransactionSize: limit.maxTransactionSize,
+      enqueued: enqueuedCount > 0,
+      enqueuedCount,
+    };
+  }
+
+  /**
+   * USD notional as priced by the Governor.
+   *
+   * @returns USD notional value, or null when none of the origins is governed
+   */
+  async toNotionalUsd(
+    origins: { wormholeChainId: number; originAddress: string }[],
+    amount: bigint,
+    decimals: number
+  ): Promise<number | null> {
+    const prices = await this.getTokenPrices();
+    for (const { wormholeChainId, originAddress } of origins) {
+      const price = prices.get(this.priceKey(wormholeChainId, originAddress));
+      if (price !== undefined) {
+        const whole = Number(amount) / 10 ** decimals;
+        return whole * price;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/xc-sdk/src/clients/index.ts
+++ b/packages/xc-sdk/src/clients/index.ts
@@ -1,3 +1,4 @@
+export * from './WormholeGovernor';
 export * from './WormholeScan';
 export * from './WormholeTransfer';
 export * from './types';

--- a/packages/xc-sdk/src/index.ts
+++ b/packages/xc-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { Wallet } from './Wallet';
 export { TransferBuilder } from './Wallet.utils';
 export { FeeSwap } from './FeeSwap';
+export { WormholeRateLimitValidation } from './transfer/WormholeRateLimitValidation';
 
 export * from './clients';
 export * from './platforms';

--- a/packages/xc-sdk/src/transfer/WormholeRateLimitValidation.ts
+++ b/packages/xc-sdk/src/transfer/WormholeRateLimitValidation.ts
@@ -1,0 +1,126 @@
+import {
+  ConfigService,
+  TransferCtx,
+  TransferValidation,
+  TransferValidationConstraint,
+  TransferValidationError,
+  Wormhole,
+} from '@galacticcouncil/xc-core';
+
+import { WormholeGovernor, WormholeRateLimit } from '../clients';
+
+export class WormholeRateLimitValidation extends TransferValidation {
+  private governor: WormholeGovernor;
+  private config: ConfigService;
+
+  constructor(
+    governor: WormholeGovernor,
+    config: ConfigService,
+    sourceConstraint: TransferValidationConstraint = () => true,
+    destinationConstraint: TransferValidationConstraint = () => true
+  ) {
+    super(sourceConstraint, destinationConstraint);
+    this.governor = governor;
+    this.config = config;
+  }
+
+  private tokenOrigins(asset: TransferCtx['asset']) {
+    const origins: { wormholeChainId: number; originAddress: string }[] = [];
+    for (const chain of this.config.chains.values()) {
+      if (!Wormhole.isKnown(chain) || !chain.getAsset(asset.key)) {
+        continue;
+      }
+      const wormhole = Wormhole.fromChain(chain);
+      try {
+        origins.push({
+          wormholeChainId: wormhole.getWormholeId(),
+          originAddress: wormhole.normalizeAddress(
+            String(chain.getAssetId(asset))
+          ),
+        });
+      } catch {
+        // Address not normalizable for this chain — skip as a candidate.
+      }
+    }
+    return origins;
+  }
+
+  async validate(ctx: TransferCtx) {
+    const { amount, asset, source, transact } = ctx;
+
+    const emitter = Wormhole.isKnown(source.chain)
+      ? source.chain
+      : transact && Wormhole.isKnown(transact.chain)
+        ? transact.chain
+        : undefined;
+
+    if (!emitter) {
+      return;
+    }
+
+    const wormhole = Wormhole.fromChain(emitter);
+    const wormholeChainId = wormhole.getWormholeId();
+
+    let state: WormholeRateLimit;
+    try {
+      state = await this.governor.getWormholeRateLimit(wormholeChainId);
+    } catch {
+      throw new TransferValidationError('Wormhole_Governor_Unreachable', {
+        chain: emitter.name,
+        error: 'wormhole.governorUnreachable',
+      });
+    }
+
+    if (!state.configured) {
+      return;
+    }
+
+    if (state.availableNotional <= 0) {
+      throw new TransferValidationError('Wormhole_RateLimit_Lockdown', {
+        chain: emitter.name,
+        enqueuedCount: state.enqueuedCount,
+        error: 'wormhole.rateLimitLockdown',
+      });
+    }
+
+    let notional: number | null;
+    try {
+      notional = await this.governor.toNotionalUsd(
+        this.tokenOrigins(asset),
+        amount,
+        source.balance.decimals
+      );
+    } catch {
+      throw new TransferValidationError('Wormhole_Governor_Unreachable', {
+        chain: emitter.name,
+        error: 'wormhole.governorUnreachable',
+      });
+    }
+
+    // Token not priced by the Governor — only the chain-level lockdown applies.
+    if (notional === null) {
+      return;
+    }
+
+    if (notional > state.maxTransactionSize) {
+      throw new TransferValidationError('Wormhole_BigTransaction', {
+        asset: asset.originSymbol,
+        chain: emitter.name,
+        notional,
+        maxTransactionSize: state.maxTransactionSize,
+        error: 'wormhole.bigTransaction',
+      });
+    }
+
+    if (notional > state.availableNotional) {
+      throw new TransferValidationError('Wormhole_RateLimit_Exceeded', {
+        asset: asset.originSymbol,
+        chain: emitter.name,
+        notional,
+        headroom: state.availableNotional,
+        limit: state.notionalLimit,
+        error: 'wormhole.rateLimitExceeded',
+      });
+    }
+  }
+}

--- a/packages/xc/src/factory.ts
+++ b/packages/xc/src/factory.ts
@@ -10,6 +10,8 @@ import { Parachain } from '@galacticcouncil/xc-core';
 
 import {
   Wallet,
+  WormholeGovernor,
+  WormholeRateLimitValidation,
   WormholeScan,
   WormholeTransfer,
 } from '@galacticcouncil/xc-sdk';
@@ -30,12 +32,16 @@ export async function createXcContext(opts: XcOpts = {}): Promise<XcCtx> {
 
   // Initialize clients
   const whScan = new WormholeScan();
+  const whGovernor = new WormholeGovernor();
   const whTransfer = new WormholeTransfer(config, hydration.parachainId);
 
   // Initialize wallet
   const wallet = new Wallet({
     configService: config,
-    transferValidations: validations,
+    transferValidations: [
+      ...validations,
+      new WormholeRateLimitValidation(whGovernor, config),
+    ],
   });
 
   // Register dex-es
@@ -46,6 +52,7 @@ export async function createXcContext(opts: XcOpts = {}): Promise<XcCtx> {
     wallet: wallet,
     wormhole: {
       scan: whScan,
+      governor: whGovernor,
       transfer: whTransfer,
     },
   } as XcCtx;

--- a/packages/xc/src/types.ts
+++ b/packages/xc/src/types.ts
@@ -1,6 +1,7 @@
 import type { ConfigService } from '@galacticcouncil/xc-core';
 import type {
   Wallet,
+  WormholeGovernor,
   WormholeScan,
   WormholeTransfer,
 } from '@galacticcouncil/xc-sdk';
@@ -12,6 +13,7 @@ export type XcCtx = {
   wallet: Wallet;
   wormhole: {
     scan: WormholeScan;
+    governor: WormholeGovernor;
     transfer: WormholeTransfer;
   };
 };


### PR DESCRIPTION
Adds pre-flight validation against the Wormhole Governor rate limits, so transfers that would be enqueued or rejected by the Governor surface a report before the user signs.

- WormholeGovernor client (xc-sdk) — wraps the wormholescan governor API (/governor/limit, /governor/config, /governor/enqueued_vaas); exposes per-chain rate-limit state and USD notional pricing by token origin.
- WormholeRateLimitValidation (xc-sdk) — resolves the emitter chain (source, or transact for MRL), prices the transfer, and emits reports for Wormhole_RateLimit_Lockdown, Wormhole_BigTransaction, Wormhole_RateLimit_Exceeded, and Wormhole_Governor_Unreachable.
- Wired into the xc factory's transferValidations and exposed as ctx.wormhole.governor.
- Adds an xc-transfer example (wormhole-ratelimit.ts) that dumps governor limits and per-asset governed pricing.