### PR TITLE
omni ema: single prefix watchEntries instead of per-pair watchValue

### DIFF
--- a/packages/sdk-next/src/pool/omni/OmniPoolClient.ts
+++ b/packages/sdk-next/src/pool/omni/OmniPoolClient.ts
@@ -10,10 +10,8 @@ import { toHex } from '@polkadot-api/utils';
 import {
   Subscription,
   distinctUntilChanged,
-  filter,
   finalize,
   map,
-  merge,
   tap,
 } from 'rxjs';
 
@@ -233,40 +231,35 @@ export class OmniPoolClient extends PoolClient<OmniPoolBase> {
   private subscribeEmaOracles(): Subscription {
     const [pool] = this.store.pools;
 
-    const oraclePairs = pool.tokens
-      .map((t) => t.id)
-      .map((id) => getEmaPair(id));
-
-    const streams = oraclePairs.map((pair) =>
-      this.api.query.EmaOracle.Oracles.watchValue(
-        ORACLE_NAME,
-        pair,
-        ORACLE_PERIOD,
-        { at: 'best' }
-      ).pipe(
-        map(({ value }) => value),
-        filter((v): v is TEmaOracle => v !== undefined),
-        map((value, index) => ({ value, index })),
-        tap(({ index }) => {
-          if (index > 0) {
-            this.log.trace('emaOracle.Oracles', pair.join(':'));
-          }
-        }),
-        map(({ value }) => ({
-          pair,
-          value,
-        }))
-      )
+    // the omnipool oracle pairs we actually care about, keyed for O(1) lookup
+    const wanted = new Set(
+      pool.tokens.map((t) => getEmaPair(t.id).join(':'))
     );
 
-    return merge(...streams)
+    // one merkle-gated subscription prefix-scoped to ORACLE_NAME instead of
+    // one watchValue per pair (~23 `value` storage reads/block -> ~1 merkle
+    // probe/block, with descendant reads only when an omnipool oracle changes).
+    return this.api.query.EmaOracle.Oracles.watchEntries(ORACLE_NAME, {
+      at: 'best',
+    })
       .pipe(
+        distinctUntilChanged((_, current) => !current.deltas),
+        map((value, index) => ({ value, index })),
+        tap(({ value, index }) => {
+          if (index > 0) {
+            this.log.trace('emaOracle.Oracles', value.deltas?.upserted);
+          }
+        }),
         finalize(() => this.emaOracles.clear()),
         this.watchGuard('emaOracle.Oracles')
       )
-      .subscribe((delta) => {
-        const { pair, value } = delta;
-        this.emaOracles.set(value, pair);
+      .subscribe(({ value: { deltas } }) => {
+        deltas?.upserted.forEach((delta) => {
+          const [, pair, period] = delta.args;
+          if (period.type !== ORACLE_PERIOD.type) return;
+          if (!wanted.has(pair.join(':'))) return;
+          this.emaOracles.set(delta.value, pair);
+        });
       });
   }
 


### PR DESCRIPTION
## Problem

`OmniPoolClient.subscribeEmaOracles` opens one `EmaOracle.Oracles.watchValue(ORACLE_NAME, pair, Short)` subscription **per omnipool oracle pair**. With ~23 omnipool assets that is ~23 targeted `chainHead_v1_storage` `value` reads on the `EmaOracle.Oracles` map **every block**, regardless of whether any oracle changed. Measured on mainnet it is the single largest storage-map cost in the per-block read profile (~30% of all storage ops).

## Fix

Subscribe **once** to a prefix-scoped `EmaOracle.Oracles.watchEntries(ORACLE_NAME, { at: 'best' })` (the partial-key form the papi typed API supports) and filter `deltas.upserted` to the omnipool's `(pair, Short)` keys, setting `this.emaOracles` exactly as before. `watchEntries` is merkle-gated: it emits one `closestDescendantMerkleValue` probe per block and only issues `descendantsValues` reads when the prefix subtree actually changes. This is the same pattern already used by the sibling `StableSwapClient.subscribeEmaOracles`.

Public API is unchanged — `getPoolFees` still reads the same `emaOracles` scope; only the subscription wiring changes.

## Benchmark (mainnet `wss://hdx.tarn.hydration.cloud`, single chainHead follow, ~16-17 block window, 23 omnipool assets)

`EmaOracle.Oracles` storage ops/block:

| | before (master) | after (this PR) |
|---|---|---|
| `value` reads | 44.7 | **0** |
| `closestDescendantMerkleValue` | 1.0 | 3.6 |
| `descendantsValues` | 0.1 | 0.6 |
| **map total / block** | **45.8** | **4.25** |
| share of all storage ops | 29.7% | 3.2% |

Total client storage ops/block dropped 154 → 131. ~41 fewer EmaOracle reads/block — a **~10.8x** reduction on this map. The per-pair `value` fan-out is eliminated entirely; the residual is cheap merkle probing.

## Regression

- Existing `sdk-next` jest suite stays green (15 suites / 57 tests pass on this branch).
- Functional equivalence vs master, 12 sample pairs via `router.getBestSell` + `router.getSpotPrice` on mainnet: **routes identical 12/12**, spot prices within 0.5% (residual is one-block balance drift between the two captures, not the change). The change reduces reads, it does not alter values.

Draft pending maintainer review of the merkle-probe trade-off and partial-key `watchEntries` usage.
