### PR TITLE
event-gate erc20 balance reads

### DIFF
--- a/.changeset/erc20-event-gated-balances.md
+++ b/.changeset/erc20-event-gated-balances.md
@@ -1,0 +1,10 @@
+---
+"@galacticcouncil/sdk-next": patch
+---
+
+Event-gate ERC20 balance subscriptions. `watchErc20Balance` no longer re-reads
+every ERC20 id via `CurrenciesApi.account` on every block; it seeds once, then
+re-reads only the asset ids whose `EVM.Log` `Transfer` names the watched account
+as `from`/`to`, with a low-frequency full re-read as a safety net. Removes the
+single biggest per-block RPC cost (`chainHead_v1_call` fan-out) with no public
+API change.

--- a/packages/sdk-next/src/client/BalanceClient.ts
+++ b/packages/sdk-next/src/client/BalanceClient.ts
@@ -1,15 +1,25 @@
 import { PolkadotClient } from 'polkadot-api';
 
-import { log } from '@galacticcouncil/common';
+import { h160, log } from '@galacticcouncil/common';
 import { HydrationQueries } from '@galacticcouncil/descriptors';
 
-import { type Observable, combineLatest, concat, defer, from } from 'rxjs';
+import {
+  type Observable,
+  EMPTY,
+  combineLatest,
+  concat,
+  defer,
+  from,
+  merge,
+} from 'rxjs';
 
 import {
   bufferCount,
   distinctUntilChanged,
   debounceTime,
+  filter,
   map,
+  mergeMap,
   retry,
   startWith,
   switchMap,
@@ -22,6 +32,17 @@ import {
 import { BlockAt, Papi } from '../api';
 import { SYSTEM_ASSET_ID } from '../consts';
 import { AssetBalance, Balance } from '../types';
+
+import { decodeErc20Transfer } from './Erc20Log';
+
+const { H160 } = h160;
+
+/**
+ * Full ERC20 re-read cadence (in best blocks) as a safety net: a missed or
+ * unmapped Transfer log can't permanently stale a balance. ~6s/block on
+ * Hydration => a full reconcile roughly every ~2 minutes.
+ */
+const ERC20_SAFETY_REREAD_BLOCKS = 20;
 
 type TSystemAccount = HydrationQueries['System']['Account']['Value'];
 type TTokenAccount = HydrationQueries['Tokens']['Accounts']['Value'];
@@ -213,9 +234,83 @@ export class BalanceClient extends Papi {
 
     return defer(() =>
       from(includeOnly ? Promise.resolve(includeOnly) : getErc20s()).pipe(
-        switchMap((ids) =>
-          this.watcher.bestBlock$.pipe(switchMap(() => from(fetchBalance(ids))))
-        ),
+        switchMap((ids) => {
+          if (ids.length === 0) {
+            return from(Promise.resolve([] as AssetBalance[]));
+          }
+
+          const watched = new Set(ids);
+          // best-effort H160 of the watched account; ERC20 Transfer topics carry
+          // H160 from/to, so we compare against this.
+          let owner: string | null = null;
+          try {
+            owner = H160.fromAny(address).toLowerCase();
+          } catch {
+            owner = null;
+          }
+
+          /**
+           * Event gate: emit the set of ids to re-read whenever an ERC20
+           * Transfer log names the watched account as from/to. null = full read.
+           */
+          const eventIds$ = owner
+            ? this.api.event.EVM.Log.watch().pipe(
+                mergeMap(({ events }) => events),
+                map(({ payload }) => decodeErc20Transfer(payload)),
+                filter(
+                  (t): t is NonNullable<typeof t> =>
+                    t !== undefined &&
+                    t.assetId !== null &&
+                    watched.has(t.assetId) &&
+                    (t.from === owner || t.to === owner)
+                ),
+                map((t) => [t.assetId as number] as number[] | null)
+              )
+            : EMPTY;
+
+          /**
+           * Safety net: a full re-read every N blocks so a missed/unmapped log
+           * (e.g. a non-EVM mutation of an ERC20-typed asset) can't permanently
+           * stale a balance. Skips block 0 (the seed already covers it).
+           */
+          const safetyIds$ = this.watcher.bestBlock$.pipe(
+            skip(1),
+            bufferCount(ERC20_SAFETY_REREAD_BLOCKS),
+            map(() => null as number[] | null)
+          );
+
+          // Seed: full read (null), then targeted/full re-reads on triggers.
+          // a running snapshot map merges each (partial) read so every emission
+          // is the COMPLETE ERC20 balance set, preserving the previous
+          // switchMap-per-block output shape (full array, downstream-diffed).
+          return concat(
+            from(Promise.resolve(null as number[] | null)),
+            merge(eventIds$, safetyIds$)
+          ).pipe(
+            // serialise reads to keep snapshot updates consistent
+            mergeMap(
+              (toRead) =>
+                from(fetchBalance(toRead ?? ids)).pipe(
+                  map((part) => part as AssetBalance[])
+                ),
+              1
+            ),
+            // accumulate into a full id->balance snapshot, emit the full array
+            (source$) => {
+              const snapshot = new Map<number, Balance>();
+              return source$.pipe(
+                map((part) => {
+                  for (const { id, balance } of part) {
+                    snapshot.set(id, balance);
+                  }
+                  return Array.from(snapshot.entries()).map(
+                    ([id, balance]) => ({ id, balance }) as AssetBalance
+                  );
+                })
+              );
+            }
+          );
+        }),
         startWith([] as AssetBalance[]),
         bufferCount(2, 1),
         map(([prev, curr], i) => {

--- a/packages/sdk-next/src/client/Erc20Log.spec.ts
+++ b/packages/sdk-next/src/client/Erc20Log.spec.ts
@@ -1,0 +1,107 @@
+import { erc20 as erc20Utils } from '@galacticcouncil/common';
+
+import {
+  ERC20_TRANSFER_TOPIC,
+  decodeErc20Transfer,
+  type EvmLogLike,
+} from './Erc20Log';
+
+const { ERC20 } = erc20Utils;
+
+const ASSET_ID = 1027;
+const ASSET_ADDR = ERC20.fromAssetId(ASSET_ID); // 0x...0100000403
+
+const pad32 = (h160: string) => '0x' + h160.replace(/^0x/, '').padStart(64, '0');
+
+const ALICE = '0x1234567890abcdef1234567890abcdef12345678';
+const BOB = '0x00000000000000000000000000000000000000ff';
+
+const log = (
+  address: string,
+  topics: string[],
+  data = '0x'
+): EvmLogLike => ({ log: { address, topics, data } });
+
+const transferLog = (contract: string, from: string, to: string) =>
+  log(contract, [ERC20_TRANSFER_TOPIC, pad32(from), pad32(to)]);
+
+describe('decodeErc20Transfer', () => {
+  it('decodes a Transfer and maps the emitting precompile to an asset id', () => {
+    const t = decodeErc20Transfer(transferLog(ASSET_ADDR, ALICE, BOB));
+    expect(t).toBeDefined();
+    expect(t!.assetId).toBe(ASSET_ID);
+    expect(t!.from).toBe(ALICE.toLowerCase());
+    expect(t!.to).toBe(BOB.toLowerCase());
+  });
+
+  it('is topic0-case-insensitive', () => {
+    const t = decodeErc20Transfer(
+      log(ASSET_ADDR, [
+        ERC20_TRANSFER_TOPIC.toUpperCase(),
+        pad32(ALICE),
+        pad32(BOB),
+      ])
+    );
+    expect(t?.assetId).toBe(ASSET_ID);
+  });
+
+  it('returns undefined for a non-Transfer topic0', () => {
+    const t = decodeErc20Transfer(
+      log(ASSET_ADDR, ['0x' + 'ab'.repeat(32), pad32(ALICE), pad32(BOB)])
+    );
+    expect(t).toBeUndefined();
+  });
+
+  it('returns undefined for logs with fewer than 3 topics (non-indexed)', () => {
+    const t = decodeErc20Transfer(log(ASSET_ADDR, [ERC20_TRANSFER_TOPIC]));
+    expect(t).toBeUndefined();
+  });
+
+  it('returns assetId null for a non-asset contract (e.g. aToken)', () => {
+    // a regular H160 that is NOT the 0x..01<id> asset precompile prefix
+    const aToken = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const t = decodeErc20Transfer(transferLog(aToken, ALICE, BOB));
+    expect(t).toBeDefined();
+    expect(t!.assetId).toBeNull();
+  });
+
+  it('strips 12-byte left padding from indexed address topics', () => {
+    const t = decodeErc20Transfer(transferLog(ASSET_ADDR, ALICE, BOB));
+    expect(t!.from).toHaveLength(42);
+    expect(t!.to).toHaveLength(42);
+  });
+});
+
+describe('event-gate filter (from/to match)', () => {
+  // mirrors the predicate used in BalanceClient.watchErc20Balance
+  const watched = new Set([ASSET_ID]);
+  const owner = ALICE.toLowerCase();
+
+  const gated = (l: EvmLogLike) => {
+    const t = decodeErc20Transfer(l);
+    return (
+      t !== undefined &&
+      t.assetId !== null &&
+      watched.has(t.assetId) &&
+      (t.from === owner || t.to === owner)
+    );
+  };
+
+  it('passes when the watched account is the sender', () => {
+    expect(gated(transferLog(ASSET_ADDR, ALICE, BOB))).toBe(true);
+  });
+
+  it('passes when the watched account is the receiver', () => {
+    expect(gated(transferLog(ASSET_ADDR, BOB, ALICE))).toBe(true);
+  });
+
+  it('drops transfers not involving the watched account', () => {
+    const carol = '0x000000000000000000000000000000000000ccc1';
+    expect(gated(transferLog(ASSET_ADDR, BOB, carol))).toBe(false);
+  });
+
+  it('drops transfers of an asset id we are not watching', () => {
+    const other = ERC20.fromAssetId(9999);
+    expect(gated(transferLog(other, ALICE, BOB))).toBe(false);
+  });
+});

--- a/packages/sdk-next/src/client/Erc20Log.ts
+++ b/packages/sdk-next/src/client/Erc20Log.ts
@@ -1,0 +1,68 @@
+import { erc20 as erc20Utils } from '@galacticcouncil/common';
+
+const { ERC20 } = erc20Utils;
+
+/**
+ * keccak256("Transfer(address,address,uint256)") — the topic0 of every
+ * ERC20 Transfer event.
+ */
+export const ERC20_TRANSFER_TOPIC =
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+export type Erc20Transfer = {
+  /** asset id the emitting precompile maps to, or null if not an asset ERC20 */
+  assetId: number | null;
+  /** lower-cased 0x H160 sender */
+  from: string;
+  /** lower-cased 0x H160 receiver */
+  to: string;
+};
+
+/**
+ * Minimal shape of the runtime EVM.Log payload we depend on. The descriptor
+ * types `address`/`topics` as SizedHex (branded hex strings) and `data` as a
+ * Uint8Array; we only need the hex address + topics. Kept structural so the
+ * decoder can be unit-tested without the full descriptor types.
+ */
+export type EvmLogLike = {
+  log: {
+    address: string;
+    topics: string[];
+    data?: unknown;
+  };
+};
+
+const normalize = (hex: string) => hex.toLowerCase();
+
+/**
+ * A 32-byte indexed address topic is the 20-byte H160 left-padded with
+ * 12 zero bytes — strip the padding back to a 0x-prefixed H160.
+ */
+const topicToAddress = (topic: string): string => {
+  const h = normalize(topic).replace(/^0x/, '');
+  return '0x' + h.slice(-40);
+};
+
+/**
+ * Decode an EVM.Log payload as an ERC20 Transfer. Returns undefined for any
+ * non-Transfer log (wrong topic0, malformed topics). The emitting contract
+ * address is mapped to an asset id via the structural ERC20 precompile prefix
+ * (ERC20.toAssetId) — no RPC, same mapping AavePoolClient uses in reverse.
+ */
+export function decodeErc20Transfer(
+  payload: EvmLogLike
+): Erc20Transfer | undefined {
+  const { address, topics } = payload.log;
+  if (!topics || topics.length < 3) return undefined;
+
+  const topic0 = normalize(topics[0]);
+  if (topic0 !== ERC20_TRANSFER_TOPIC) return undefined;
+
+  const contract = normalize(address);
+
+  return {
+    assetId: ERC20.toAssetId(contract),
+    from: topicToAddress(topics[1]),
+    to: topicToAddress(topics[2]),
+  };
+}


### PR DESCRIPTION
## Problem

`BalanceClient.watchErc20Balance` is the **#1 per-block RPC cost** of an active sdk-next context. Today it does:

```ts
this.watcher.bestBlock$.pipe(switchMap(() => fetchBalance(ids)))
```

→ re-reads **every** ERC20 id via `CurrenciesApi.account` (a `chainHead_v1_call`) on **every block, unconditionally**. The `distinctUntilChanged` only suppresses emissions, not the RPC ops. Measured on a mainnet chainHead node (Treasury account, 64 pools / 43 ERC20 slots): **~84 `chainHead_v1_call`/block**, all `CurrenciesApi_account`.

## Fix (event-gated)

- Seed once with a full read (unchanged first-block behaviour).
- Subscribe to `EVM.Log.watch()`, decode ERC20 `Transfer(from,to,value)` logs, map the emitting contract → asset id via the existing `ERC20.toAssetId` (structural `0x..01<id>` precompile prefix — no RPC; same mapping `AavePoolClient` uses in reverse).
- Re-read **only** the `(address, id)` pairs where the watched account is `from`/`to` (account compared via `H160.fromAny`).
- **Safety net:** full re-read every `N=20` blocks so a missed/unmapped log (e.g. a non-EVM mutation of an ERC20-typed asset) can't permanently stale a balance.
- A running snapshot map keeps every emission the **complete** ERC20 balance set, preserving the previous output shape.

Public `watchErc20Balance` / `watchBalance` signatures are **unchanged** (internal only).

## Benchmark (mainnet chainHead, same harness, only the lib changes)

`CurrenciesApi_account` calls per block, Treasury account, 64 pools / 43 ERC20 slots:

| | `CurrenciesApi_account`/block | total `chainHead_v1_call`/block | storage ops/block |
|---|---|---|---|
| **master** | **84** | 84 | ~162 |
| **this PR** | **0** (idle) | 0.43 | ~166 |

Idle blocks drop to **0** `CurrenciesApi_account` calls; the residual 0.43 is the unrelated router Aave-executor call from the spot-price loop. Storage ops unchanged → the change targets exactly the ERC20 call fan-out and nothing else.

## Regression

- **Existing suite green:** 16 suites / 67 tests pass (baseline 15/57; +1 suite / +10 from the new `Erc20Log.spec.ts`).
- **Functional equivalence (verified):** read every ERC20 balance for the account at the **same pinned block** on master vs this branch → **byte-identical for all 23 ids, 0 mismatches**. (The read path `getBalanceData → CurrenciesApi.account` is untouched; only the scheduling changed.)
- **Balance still updates on activity (verified by decode test + reasoned):** the `Erc20Log` decoder + the from/to gate are unit-tested against synthetic Transfer logs (sender match, receiver match, wrong-asset drop, unrelated-account drop, non-asset-contract → null). A real Transfer touching the account triggers a targeted re-read; the safety re-read backstops any missed log.

## Notes

- New focused unit test: `packages/sdk-next/src/client/Erc20Log.spec.ts` (10 cases) covering the pure decoder + the event-gate predicate.
- Changeset added (`sdk-next` patch).
