### PR TITLE
WUD transfer fix 

### DIFF
--- a/.changeset/dull-ideas-swim.md
+++ b/.changeset/dull-ideas-swim.md
@@ -1,0 +1,7 @@
+---
+'@galacticcouncil/xc-core': patch
+'@galacticcouncil/xc-cfg': patch
+'@galacticcouncil/xc-sdk': patch
+---
+
+WUD xcm fix and assethub_cex routes fix

--- a/.changeset/lemon-owls-cover.md
+++ b/.changeset/lemon-owls-cover.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/xc-cfg': major
+---
+
+WUD xcm fix

--- a/.changeset/lemon-owls-cover.md
+++ b/.changeset/lemon-owls-cover.md
@@ -1,5 +1,0 @@
----
-'@galacticcouncil/xc-cfg': major
----
-
-WUD xcm fix and assethub_cex routes fix

--- a/.changeset/lemon-owls-cover.md
+++ b/.changeset/lemon-owls-cover.md
@@ -2,4 +2,4 @@
 '@galacticcouncil/xc-cfg': major
 ---
 
-WUD xcm fix
+WUD xcm fix and assethub_cex routes fix

--- a/packages/xc-cfg/src/builders/extrinsics/assetConversion.ts
+++ b/packages/xc-cfg/src/builders/extrinsics/assetConversion.ts
@@ -1,3 +1,4 @@
+import { encodeLocation } from '@galacticcouncil/common';
 import {
   ExtrinsicConfig,
   ExtrinsicConfigBuilder,
@@ -24,8 +25,8 @@ const swapTokensForExactTokens = (opts: SwapOpts): ExtrinsicConfigBuilder => {
       const { aIn, aOut } = swapCtx;
 
       const ctx = chain as Parachain;
-      const aInLocation = ctx.getAssetXcmLocation(aIn);
-      const aOutLocation = ctx.getAssetXcmLocation(aOut);
+      const aInLocation = encodeLocation(ctx.getAssetXcmLocation(aIn));
+      const aOutLocation = encodeLocation(ctx.getAssetXcmLocation(aOut));
 
       const maxAmountIn =
         aIn.amount + (aIn.amount * BigInt(opts.slippage)) / 100n;

--- a/packages/xc-cfg/src/builders/extrinsics/xcm/polkadotXcm.ts
+++ b/packages/xc-cfg/src/builders/extrinsics/xcm/polkadotXcm.ts
@@ -40,12 +40,15 @@ const limitedReserveTransferAssets = (): ExtrinsicConfigBuilder => ({
     const rcv = destination.chain as Parachain;
     const version = XcmVersion.v4;
 
+    const transferAssetRawLocation = locationOrError(ctx, asset);
+    const transferFeeRawLocation = locationOrError(ctx, destination.fee);
+
     const transferAssetLocation = getExtrinsicAssetLocation(
-      locationOrError(ctx, asset),
+      transferAssetRawLocation,
       version
     );
     const transferFeeLocation = getExtrinsicAssetLocation(
-      locationOrError(ctx, destination.fee),
+      transferFeeRawLocation,
       version
     );
 
@@ -75,7 +78,12 @@ const limitedReserveTransferAssets = (): ExtrinsicConfigBuilder => ({
         }
 
         // Flip asset order if general index of asset greater than fee asset
-        if (shouldFeeAssetPrecede(transferAssetLocation, transferFeeLocation)) {
+        if (
+          shouldFeeAssetPrecede(
+            transferAssetRawLocation,
+            transferFeeRawLocation
+          )
+        ) {
           return tx({
             dest: toDest(version, ctx, rcv),
             beneficiary: toBeneficiary(version, account),
@@ -441,9 +449,7 @@ const send = () => {
   };
 };
 
-function execute(
-  messageBuilder: XcmMessageBuilder
-): ExtrinsicConfigBuilder;
+function execute(messageBuilder: XcmMessageBuilder): ExtrinsicConfigBuilder;
 function execute(): { viaSnowbridge: () => ExtrinsicConfigBuilder };
 function execute(messageBuilder?: XcmMessageBuilder) {
   const buildExecute = (
@@ -477,7 +483,7 @@ function execute(messageBuilder?: XcmMessageBuilder) {
     viaSnowbridge: (): ExtrinsicConfigBuilder =>
       buildExecute(snowbridgeOutboundMessage),
   };
-};
+}
 
 export const polkadotXcm = () => {
   return {

--- a/packages/xc-cfg/src/configs/polkadot/assethub/templates.ts
+++ b/packages/xc-cfg/src/configs/polkadot/assethub/templates.ts
@@ -19,11 +19,6 @@ import { hydration, moonbeam } from '../../../chains';
 
 export const extraFee = 0;
 
-const isSwapSupported = (params: ExtrinsicConfigBuilderParams) => {
-  const { source } = params;
-  return !!source.feeSwap;
-};
-
 const isDestinationFeeSwapSupported = (
   params: ExtrinsicConfigBuilderParams
 ) => {
@@ -84,7 +79,6 @@ export function toParaReservesWithSwapTemplate(
       fee: {
         asset: asset,
         balance: BalanceBuilder().substrate().assets().account(),
-        swap: true,
       },
       destinationFee: {
         balance: BalanceBuilder().substrate().assets().account(),
@@ -99,11 +93,9 @@ export function toParaReservesWithSwapTemplate(
         asset: asset,
       },
     },
-    extrinsic: ExtrinsicDecorator(isSwapSupported, swapExtrinsicBuilder).prior(
-      ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
-        transferType: XcmTransferType.LocalReserve,
-      })
-    ),
+    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
+      transferType: XcmTransferType.LocalReserve,
+    }),
   });
 }
 

--- a/packages/xc-cfg/src/configs/polkadot/assethub/templates.ts
+++ b/packages/xc-cfg/src/configs/polkadot/assethub/templates.ts
@@ -19,6 +19,11 @@ import { hydration, moonbeam } from '../../../chains';
 
 export const extraFee = 0;
 
+const isSwapSupported = (params: ExtrinsicConfigBuilderParams) => {
+  const { source } = params;
+  return !!source.feeSwap;
+};
+
 const isDestinationFeeSwapSupported = (
   params: ExtrinsicConfigBuilderParams
 ) => {
@@ -79,6 +84,7 @@ export function toParaReservesWithSwapTemplate(
       fee: {
         asset: asset,
         balance: BalanceBuilder().substrate().assets().account(),
+        swap: !asset.isEqual(dot),
       },
       destinationFee: {
         balance: BalanceBuilder().substrate().assets().account(),
@@ -93,9 +99,12 @@ export function toParaReservesWithSwapTemplate(
         asset: asset,
       },
     },
-    extrinsic: ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
-      transferType: XcmTransferType.LocalReserve,
-    }),
+
+    extrinsic: ExtrinsicDecorator(isSwapSupported, swapExtrinsicBuilder).prior(
+      ExtrinsicBuilder().polkadotXcm().transferAssetsUsingTypeAndThen({
+        transferType: XcmTransferType.LocalReserve,
+      })
+    ),
   });
 }
 

--- a/packages/xc-cfg/src/configs/polkadot/hydration/templates.ts
+++ b/packages/xc-cfg/src/configs/polkadot/hydration/templates.ts
@@ -25,6 +25,7 @@ export const MRL_EXECUTION_FEE = 0.9; // Remote execution fee (< 0.9)
 export const MRL_XCM_FEE = 1; // Destination fee (< 0.1) + Remote execution fee (< 0.9)
 
 export const GLMR_MIN_DEST_FEE = 1; // Minimum GLMR fee to meet swap threshold
+export const HUB_EXT_USDT_DEST_FEE = 0.02;
 
 const isDestinationFeeSwapSupported = (
   params: ExtrinsicConfigBuilderParams
@@ -128,7 +129,7 @@ export function toHubExtTemplate(asset: Asset): AssetRoute {
       chain: assetHub,
       asset: asset,
       fee: {
-        amount: FeeAmountBuilder().XcmPaymentApi().calculateDestFee(),
+        amount: HUB_EXT_USDT_DEST_FEE,
         asset: usdt,
       },
     },
@@ -281,9 +282,7 @@ export function viaSnowbridgeTemplate(
     extrinsic: ExtrinsicDecorator(
       isDestinationFeeSwapSupported,
       swapExtrinsicBuilder
-    ).prior(
-      ExtrinsicBuilder().polkadotXcm().execute().viaSnowbridge()
-    ),
+    ).prior(ExtrinsicBuilder().polkadotXcm().execute().viaSnowbridge()),
     tags: fast ? [Tag.Snowbridge, Tag.SnowbridgeFast] : [Tag.Snowbridge],
   });
 }

--- a/packages/xc-core/src/utils/multilocation.ts
+++ b/packages/xc-core/src/utils/multilocation.ts
@@ -10,6 +10,8 @@ export const findNestedKey = (multilocation: object, keyToFind: any) => {
       typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue;
     if (nestedValue && nestedValue[keyToFind]) {
       foundObj.push(v);
+    } else if (nestedValue && nestedValue['type'] === keyToFind) {
+      foundObj.push({ [keyToFind]: nestedValue['value'] });
     }
     return v;
   });

--- a/packages/xc-sdk/src/platforms/substrate/SubstrateService.ts
+++ b/packages/xc-sdk/src/platforms/substrate/SubstrateService.ts
@@ -198,7 +198,8 @@ export class SubstrateService {
       }
 
       // Upward (use chain treasury account if any)
-      if (interior && interior['interior'] === 'Here') {
+      const interiorValue = interior && interior['interior'];
+      if (interiorValue === 'Here' || interiorValue?.type === 'Here') {
         return this.chain.treasury || account;
       }
     }

--- a/packages/xc/src/dex.ts
+++ b/packages/xc/src/dex.ts
@@ -21,6 +21,11 @@ const bootstrap: Record<string, DexBootstrap> = {
   },
 };
 
+// chains that share another chain's runtime and reuse its dex
+const dexAlias: Record<string, string> = {
+  assethub_cex: 'assethub',
+};
+
 export async function registerDexes(
   config: ConfigService,
   opts: XcOpts = {}
@@ -32,4 +37,10 @@ export async function registerDexes(
       chain.registerDex(dex);
     })
   );
+
+  // reuse a sibling chain's dex for chains sharing its runtime
+  for (const [alias, target] of Object.entries(dexAlias)) {
+    const chain = config.chains.get(alias) as Parachain | undefined;
+    chain?.registerDex(config.getChain(target).dex);
+  }
 }


### PR DESCRIPTION
## Fix
- Pass the **raw** locations to `shouldFeeAssetPrecede` so it can read
  `GeneralIndex` and order assets correctly (encoded locations still used for the
  payload).
- `toHubExtTemplate` (WUD→AssetHub) uses a fixed `0.02` USDT destination fee
  instead of `calculateDestFee()`, which was pricing against WUD, not USDT.
  
 - assethub_cex routes fix
 
