### PR TITLE
DCA sell function

### DIFF
--- a/.changeset/fair-gifts-draw.md
+++ b/.changeset/fair-gifts-draw.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/sdk-next': patch
+---
+
+Added dcaSell function

--- a/packages/sdk-next/src/sor/TradeScheduler.ts
+++ b/packages/sdk-next/src/sor/TradeScheduler.ts
@@ -404,6 +404,30 @@ export class TradeScheduler {
   }
 
   /**
+   * Build a DCA sell order (TWAP sell executed as DCA)
+   *
+   * @param assetIn - assetIn id
+   * @param assetOut - assetOut id
+   * @param amountInTotal - order budget
+   * @returns dca sell trade order
+   */
+  async getDcaSellOrder(
+    assetIn: number,
+    assetOut: number,
+    amountInTotal: string
+  ): Promise<TradeOrder> {
+    const order = await this.getTwapSellOrder(assetIn, assetOut, amountInTotal);
+    return {
+      ...order,
+      type: TradeOrderType.DcaSell,
+      toHuman: () => ({
+        ...order.toHuman(),
+        type: TradeOrderType.DcaSell,
+      }),
+    };
+  }
+
+  /**
    * Build a TWAP (Time-Weighted Average Price) buy order
    *
    * @param assetIn - assetIn id

--- a/packages/sdk-next/src/sor/types.ts
+++ b/packages/sdk-next/src/sor/types.ts
@@ -66,6 +66,7 @@ export interface TradeOrder extends Humanizer {
 
 export enum TradeOrderType {
   Dca = 'Dca',
+  DcaSell = 'DcaSell',
   TwapSell = 'TwapSell',
   TwapBuy = 'TwapBuy',
 }

--- a/packages/sdk-next/src/tx/OrderTxBuilder.ts
+++ b/packages/sdk-next/src/tx/OrderTxBuilder.ts
@@ -59,6 +59,8 @@ export class OrderTxBuilder extends TxBuilder {
     switch (type) {
       case TradeOrderType.Dca:
         return this.buildDcaTx();
+      case TradeOrderType.DcaSell:
+        return this.buildDcaSellTx();
       case TradeOrderType.TwapSell:
         return this.buildTwapSellTx();
       case TradeOrderType.TwapBuy:
@@ -103,6 +105,43 @@ export class OrderTxBuilder extends TxBuilder {
     }
 
     return this.wrapTx('DcaSchedule', tx);
+  }
+
+  private async buildDcaSellTx(): Promise<Tx> {
+    const {
+      amountIn,
+      assetIn,
+      assetOut,
+      tradeAmountIn,
+      tradePeriod,
+      tradeRoute,
+    } = this.order;
+
+    let tx: Transaction = this.api.tx.DCA.schedule({
+      schedule: {
+        owner: this.beneficiary,
+        period: tradePeriod,
+        max_retries: this.maxRetries,
+        total_amount: amountIn,
+        slippage: this.slippagePct * 10000,
+        stability_threshold: undefined,
+        order: Enum('Sell', {
+          asset_in: assetIn,
+          asset_out: assetOut,
+          amount_in: tradeAmountIn,
+          min_amount_out: 0n,
+          route: tradeRoute as any,
+        }),
+      },
+      start_execution_block: undefined,
+    });
+
+    const hasDebt = await this.aaveUtils.hasBorrowPositions(this.beneficiary);
+    if (hasDebt) {
+      tx = await this.dispatchWithExtraGas(tx);
+    }
+
+    return this.wrapTx('DcaSchedule.dcaSell', tx);
   }
 
   private async buildTwapSellTx(): Promise<Tx> {


### PR DESCRIPTION
Large sell-intent TWAP orders stall with `DCA.TradeLimitReached`: the
per-trade `min_amount_out` floor is frozen at setup, then the order's own
price impact breaches it and every slice fails until the schedule
terminates.

This adds a `DcaSell` order type that builds the sell as a DCA `Sell` with
`min_amount_out = 0` — the same shape the DCA product has shipped for years.
Per-trade protection then comes from the pallet's adaptive oracle slippage
limit (recomputed each block from the schedule's `slippage`), which tracks
the market instead of a stale floor.