### PR TITLE
Wormhole ntt rate limits 

### DIFF
--- a/.changeset/olive-bats-share.md
+++ b/.changeset/olive-bats-share.md
@@ -1,0 +1,6 @@
+---
+'@galacticcouncil/xc-core': minor
+'@galacticcouncil/xc-cfg': minor
+---
+
+Wormhole ntt rate limits support

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,10 +27,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: 🖊️ Bump version
-        run: |
-          git config user.name "GitHub Action"
-          git config user.email "action@github.com"
-          npm run changeset:snapshot -- --pr $PR --sha $COMMIT_SHA --output release-plan.json
+        run: npm run changeset:snapshot -- --pr $PR --sha $COMMIT_SHA --output release-plan.json
         env:
           PR: ${{ github.event.pull_request.number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,10 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: 🖊️ Bump version
-        run: npm run changeset:snapshot -- --pr $PR --sha $COMMIT_SHA --output release-plan.json
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          npm run changeset:snapshot -- --pr $PR --sha $COMMIT_SHA --output release-plan.json
         env:
           PR: ${{ github.event.pull_request.number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/examples/xc-transfer/src/circuitbreaker.ts
+++ b/examples/xc-transfer/src/circuitbreaker.ts
@@ -1,11 +1,17 @@
 import { Parachain } from '@galacticcouncil/xc-core';
-import { clients } from '@galacticcouncil/xc-cfg';
+import { clients, tags } from '@galacticcouncil/xc-cfg';
 
 import { xc } from './setup';
 
 const { config } = xc;
+const { Tag } = tags;
 
-const { HydrationClient, ASSET_LOCKDOWN_PERIOD_BLOCKS } = clients;
+const {
+  HydrationClient,
+  ASSET_LOCKDOWN_PERIOD_BLOCKS,
+  getNttInboundLimit,
+  getNttOutboundLimit,
+} = clients;
 
 const HDX_DECIMALS = 12;
 const BLOCK_TIME_MS = 6_000;
@@ -107,4 +113,86 @@ const rows = Array.from(states.values()).map((s) => {
 console.table(rows);
 console.groupEnd();
 
+console.groupEnd();
+
+// --- Wormhole ntt rate limits ---
+//
+// The circuit breaker only governs the hydration side; an ntt transfer is
+// metered a second time by its manager, per token & per direction. Driven
+// off the `Ntt` tag, so a newly wired token shows up here on its own.
+
+/**
+ * Headroom left right now, out of the limit.
+ *
+ * The hydration legs read in the hundreds of billions, which is a real
+ * metered limit set high enough never to bind - not an opt out. Only
+ * `rateLimitDuration == 0` is that, and it reads as no window at all.
+ */
+function headroom(rl: clients.NttRateLimit, decimals: number): string {
+  if (rl.windowMs === 0) return 'not metered';
+  return `${fmt(rl.capacity, decimals)} / ${fmt(rl.limit, decimals)}`;
+}
+
+/**
+ * How far below the limit the bucket sat the last time it was touched.
+ *
+ * Unlike the circuit breaker above, this is not a windowed counter - the
+ * bucket refills linearly, so headroom is back at the limit within
+ * `amount / (limit / window)` seconds and reads as no traffic ever. This
+ * residual is the only volume the manager still remembers.
+ *
+ * A transfer consumes at both ends *and* backfills the two opposite legs,
+ * so an outbound reading 0 alongside a recent stamp means the traffic went
+ * the other way - which is why the two directions of a pair mirror.
+ */
+function lastTx(rl: clients.NttRateLimit, decimals: number): string {
+  const took = rl.limit - rl.capacityAtLastTx;
+  if (rl.lastTxMs === 0 || took === 0n) return '–';
+  return `${fmt(took, decimals)} (${hours(BigInt(Date.now() - rl.lastTxMs))} ago)`;
+}
+
+const nttRoutes = Array.from(config.routes.values()).flatMap((chainRoutes) =>
+  chainRoutes
+    .getRoutes()
+    .filter((route) => route.tags?.includes(Tag.Ntt))
+    .map((route) => ({ source: chainRoutes.chain, route }))
+);
+
+console.group('Wormhole NTT Rate Limits (capacity / limit per 24h)');
+const nttRows = await Promise.all(
+  nttRoutes.map(async ({ source, route }) => {
+    const destination = route.destination.chain;
+    const sent = route.source.asset;
+    const received = route.destination.asset;
+    const leg = `${source.name} → ${destination.name}`;
+
+    try {
+      const [out, inbound] = await Promise.all([
+        getNttOutboundLimit(source, sent),
+        getNttInboundLimit(destination, received, source),
+      ]);
+
+      const sentDecimals = source.getAssetDecimals(sent) ?? 0;
+      const receivedDecimals = destination.getAssetDecimals(received) ?? 0;
+
+      return {
+        leg: leg,
+        asset: sent.originSymbol,
+        send: headroom(out, sentDecimals),
+        sendLast: lastTx(out, sentDecimals),
+        receive: headroom(inbound, receivedDecimals),
+        receiveLast: lastTx(inbound, receivedDecimals),
+        window: hours(out.windowMs),
+      };
+    } catch (e) {
+      return {
+        leg: leg,
+        asset: sent.originSymbol,
+        send: e instanceof Error ? e.message : String(e),
+      };
+    }
+  })
+);
+
+console.table(nttRows);
 console.groupEnd();

--- a/examples/xc-transfer/src/circuitbreaker.ts
+++ b/examples/xc-transfer/src/circuitbreaker.ts
@@ -6,12 +6,7 @@ import { xc } from './setup';
 const { config } = xc;
 const { Tag } = tags;
 
-const {
-  HydrationClient,
-  ASSET_LOCKDOWN_PERIOD_BLOCKS,
-  getNttInboundLimit,
-  getNttOutboundLimit,
-} = clients;
+const { HydrationClient, ASSET_LOCKDOWN_PERIOD_BLOCKS, NttClient } = clients;
 
 const HDX_DECIMALS = 12;
 const BLOCK_TIME_MS = 6_000;
@@ -168,8 +163,8 @@ const nttRows = await Promise.all(
 
     try {
       const [out, inbound] = await Promise.all([
-        getNttOutboundLimit(source, sent),
-        getNttInboundLimit(destination, received, source),
+        new NttClient(source, sent).getOutboundLimit(),
+        new NttClient(destination, received).getInboundLimit(source),
       ]);
 
       const sentDecimals = source.getAssetDecimals(sent) ?? 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17651,8 +17651,8 @@
         "@types/big.js": "^6.2.2"
       },
       "peerDependencies": {
-        "@galacticcouncil/common": ">=1.0.0",
-        "@galacticcouncil/descriptors": ">=2.2.0",
+        "@galacticcouncil/common": ">=1.2.0",
+        "@galacticcouncil/descriptors": ">=2.6.0",
         "polkadot-api": "^2.1.7",
         "viem": "^2.38.3"
       }

--- a/packages/xc-cfg/src/clients/bridge/index.ts
+++ b/packages/xc-cfg/src/clients/bridge/index.ts
@@ -1,0 +1,1 @@
+export * from './ntt';

--- a/packages/xc-cfg/src/clients/bridge/ntt.ts
+++ b/packages/xc-cfg/src/clients/bridge/ntt.ts
@@ -1,0 +1,274 @@
+import {
+  Abi,
+  AnyChain,
+  Asset,
+  EvmChain,
+  Ntt as NttRegistry,
+  NttTokenDef,
+  SolanaChain,
+  SuiChain,
+  suiPkg,
+  Wormhole as Wh,
+} from '@galacticcouncil/xc-core';
+
+import { PublicKey } from '@solana/web3.js';
+
+export interface NttRateLimit {
+  capacity: bigint;
+  limit: bigint;
+  windowMs: number;
+  capacityAtLastTx: bigint;
+  lastTxMs: number;
+}
+
+const UNMETERED: NttRateLimit = {
+  capacity: 0n,
+  limit: 0n,
+  windowMs: 0,
+  capacityAtLastTx: 0n,
+  lastTxMs: 0,
+};
+
+// Mirror manager's linear refill (rate_limit::capacity_at).
+function capacityAt(
+  limit: bigint,
+  capacityAtLastTx: bigint,
+  lastTxTimestamp: bigint,
+  now: bigint,
+  duration: bigint
+): bigint {
+  const elapsed = now > lastTxTimestamp ? now - lastTxTimestamp : 0n;
+  const refilled = capacityAtLastTx + (limit * elapsed) / duration;
+  return refilled < limit ? refilled : limit;
+}
+
+// TrimmedAmount is a uint72 - `amount << 8 | decimals`.
+function untrim(packed: bigint, decimals: number): bigint {
+  const amount = packed >> 8n;
+  const trimmedDecimals = Number(packed & 0xffn);
+  return amount * 10n ** BigInt(decimals - trimmedDecimals);
+}
+
+async function getEvmLimit(
+  chain: EvmChain,
+  ntt: NttTokenDef,
+  from?: number
+): Promise<NttRateLimit> {
+  const provider = chain.evmClient.getProvider();
+  const abi = Abi.NttManager;
+  const address = ntt.manager as `0x${string}`;
+
+  const [duration, decimals, capacity, params] = await Promise.all([
+    provider.readContract({
+      abi,
+      address,
+      functionName: 'rateLimitDuration',
+    }) as Promise<bigint>,
+    provider.readContract({
+      abi,
+      address,
+      functionName: 'tokenDecimals',
+    }) as Promise<number>,
+    (from === undefined
+      ? provider.readContract({
+          abi,
+          address,
+          functionName: 'getCurrentOutboundCapacity',
+        })
+      : provider.readContract({
+          abi,
+          address,
+          functionName: 'getCurrentInboundCapacity',
+          args: [from],
+        })) as Promise<bigint>,
+    (from === undefined
+      ? provider.readContract({
+          abi,
+          address,
+          functionName: 'getOutboundLimitParams',
+        })
+      : provider.readContract({
+          abi,
+          address,
+          functionName: 'getInboundLimitParams',
+          args: [from],
+        })) as Promise<{
+      limit: bigint;
+      currentCapacity: bigint;
+      lastTxTimestamp: bigint;
+    }>,
+  ]);
+
+  if (duration === 0n) {
+    return UNMETERED;
+  }
+
+  return {
+    capacity: capacity,
+    limit: untrim(params.limit, decimals),
+    windowMs: Number(duration) * 1000,
+    capacityAtLastTx: untrim(params.currentCapacity, decimals),
+    lastTxMs: Number(params.lastTxTimestamp) * 1000,
+  };
+}
+
+const SOLANA_RATE_LIMIT_DURATION = 60 * 60 * 24;
+const OUTBOX_RATE_LIMIT_OFFSET = 8;
+const INBOX_RATE_LIMIT_OFFSET = 8 + 1;
+
+function decodeSolanaRateLimit(data: Uint8Array, offset: number) {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return {
+    limit: view.getBigUint64(offset, true),
+    capacityAtLastTx: view.getBigUint64(offset + 8, true),
+    lastTxTimestamp: view.getBigInt64(offset + 16, true),
+  };
+}
+
+function solanaRateLimitPda(
+  ntt: NttTokenDef,
+  from?: number
+): { pda: PublicKey; offset: number } {
+  const programId = new PublicKey(ntt.manager);
+  const encoder = new TextEncoder();
+
+  if (from === undefined) {
+    const [pda] = PublicKey.findProgramAddressSync(
+      [encoder.encode('outbox_rate_limit')],
+      programId
+    );
+    return { pda, offset: OUTBOX_RATE_LIMIT_OFFSET };
+  }
+
+  const chainId = new Uint8Array(2);
+  new DataView(chainId.buffer).setUint16(0, from, false);
+  const [pda] = PublicKey.findProgramAddressSync(
+    [encoder.encode('inbox_rate_limit'), chainId],
+    programId
+  );
+  return { pda, offset: INBOX_RATE_LIMIT_OFFSET };
+}
+
+async function getSolanaLimit(
+  chain: SolanaChain,
+  ntt: NttTokenDef,
+  from?: number
+): Promise<NttRateLimit> {
+  const { pda, offset } = solanaRateLimitPda(ntt, from);
+  const account = await chain.connection.getAccountInfo(pda);
+
+  if (!account) {
+    return UNMETERED;
+  }
+
+  const { limit, capacityAtLastTx, lastTxTimestamp } = decodeSolanaRateLimit(
+    account.data,
+    offset
+  );
+  const now = BigInt(Math.floor(Date.now() / 1000));
+
+  return {
+    capacity: capacityAt(
+      limit,
+      capacityAtLastTx,
+      lastTxTimestamp,
+      now,
+      BigInt(SOLANA_RATE_LIMIT_DURATION)
+    ),
+    limit: limit,
+    windowMs: SOLANA_RATE_LIMIT_DURATION * 1000,
+    capacityAtLastTx: capacityAtLastTx,
+    lastTxMs: Number(lastTxTimestamp) * 1000,
+  };
+}
+
+const SUI_RATE_LIMIT_DURATION_MS = 60 * 60 * 24 * 1000;
+
+// Sui stores RateLimitState in *local* token decimals, not as the packed
+// TrimmedAmount the evm manager keeps - so no untrimming here. There is no
+// upstream sui ntt binding to mirror (wormhole-sdk-ts ships no ntt protocol,
+// and native-token-transfers only binds solana), so this is off a live read:
+// the SUI manager reads limit 1e14 against 9 decimals = 100k SUI, and each
+// peer carries its own `token_decimals` for confirmation.
+function toSuiRateLimit(fields: Record<string, any>): NttRateLimit {
+  const limit = BigInt(fields['limit']);
+  const capacityAtLastTx = BigInt(fields['capacity_at_last_tx']);
+  const lastTxTimestamp = BigInt(fields['last_tx_timestamp']);
+  const now = BigInt(Date.now());
+
+  return {
+    capacity: capacityAt(
+      limit,
+      capacityAtLastTx,
+      lastTxTimestamp,
+      now,
+      BigInt(SUI_RATE_LIMIT_DURATION_MS)
+    ),
+    limit: limit,
+    windowMs: SUI_RATE_LIMIT_DURATION_MS,
+    capacityAtLastTx: capacityAtLastTx,
+    // Sui already stamps in milliseconds.
+    lastTxMs: Number(lastTxTimestamp),
+  };
+}
+
+async function getSuiLimit(
+  chain: SuiChain,
+  ntt: NttTokenDef,
+  from?: number
+): Promise<NttRateLimit> {
+  const client = chain.client;
+  const state = await suiPkg.getObject(client, ntt.manager);
+
+  if (from === undefined) {
+    const rateLimit = state.fields['outbox']?.fields?.rate_limit?.fields;
+    return rateLimit ? toSuiRateLimit(rateLimit) : UNMETERED;
+  }
+
+  const peers = state.fields['peers']?.fields?.id?.id;
+  if (!peers) {
+    return UNMETERED;
+  }
+
+  const { data } = await client.getDynamicFieldObject({
+    parentId: peers,
+    name: { type: 'u16', value: from },
+  });
+  const content = data?.content as { fields?: Record<string, any> };
+  const rateLimit =
+    content?.fields?.['value']?.fields?.inbound_rate_limit?.fields;
+  return rateLimit ? toSuiRateLimit(rateLimit) : UNMETERED;
+}
+
+function getLimit(
+  chain: AnyChain,
+  ntt: NttTokenDef,
+  from?: number
+): Promise<NttRateLimit> {
+  if (chain instanceof SolanaChain) {
+    return getSolanaLimit(chain, ntt, from);
+  }
+  if (chain instanceof SuiChain) {
+    return getSuiLimit(chain, ntt, from);
+  }
+  return getEvmLimit(chain as EvmChain, ntt, from);
+}
+
+export async function getNttOutboundLimit(
+  chain: AnyChain,
+  asset: Asset
+): Promise<NttRateLimit> {
+  return getLimit(chain, NttRegistry.fromChain(chain, asset));
+}
+
+export async function getNttInboundLimit(
+  chain: AnyChain,
+  asset: Asset,
+  from: AnyChain
+): Promise<NttRateLimit> {
+  return getLimit(
+    chain,
+    NttRegistry.fromChain(chain, asset),
+    Wh.fromChain(from).getWormholeId()
+  );
+}

--- a/packages/xc-cfg/src/clients/bridge/ntt.ts
+++ b/packages/xc-cfg/src/clients/bridge/ntt.ts
@@ -1,8 +1,8 @@
 import {
   Abi,
   AnyChain,
+  AnyEvmChain,
   Asset,
-  EvmChain,
   Ntt as NttRegistry,
   NttTokenDef,
   SolanaChain,
@@ -10,6 +10,7 @@ import {
   suiPkg,
   Wormhole as Wh,
 } from '@galacticcouncil/xc-core';
+import { big } from '@galacticcouncil/common';
 
 import { PublicKey } from '@solana/web3.js';
 
@@ -46,11 +47,11 @@ function capacityAt(
 function untrim(packed: bigint, decimals: number): bigint {
   const amount = packed >> 8n;
   const trimmedDecimals = Number(packed & 0xffn);
-  return amount * 10n ** BigInt(decimals - trimmedDecimals);
+  return amount * big.pow10(decimals - trimmedDecimals);
 }
 
 async function getEvmLimit(
-  chain: EvmChain,
+  chain: AnyEvmChain,
   ntt: NttTokenDef,
   from?: number
 ): Promise<NttRateLimit> {
@@ -184,12 +185,6 @@ async function getSolanaLimit(
 
 const SUI_RATE_LIMIT_DURATION_MS = 60 * 60 * 24 * 1000;
 
-// Sui stores RateLimitState in *local* token decimals, not as the packed
-// TrimmedAmount the evm manager keeps - so no untrimming here. There is no
-// upstream sui ntt binding to mirror (wormhole-sdk-ts ships no ntt protocol,
-// and native-token-transfers only binds solana), so this is off a live read:
-// the SUI manager reads limit 1e14 against 9 decimals = 100k SUI, and each
-// peer carries its own `token_decimals` for confirmation.
 function toSuiRateLimit(fields: Record<string, any>): NttRateLimit {
   const limit = BigInt(fields['limit']);
   const capacityAtLastTx = BigInt(fields['capacity_at_last_tx']);
@@ -207,7 +202,6 @@ function toSuiRateLimit(fields: Record<string, any>): NttRateLimit {
     limit: limit,
     windowMs: SUI_RATE_LIMIT_DURATION_MS,
     capacityAtLastTx: capacityAtLastTx,
-    // Sui already stamps in milliseconds.
     lastTxMs: Number(lastTxTimestamp),
   };
 }
@@ -240,35 +234,33 @@ async function getSuiLimit(
   return rateLimit ? toSuiRateLimit(rateLimit) : UNMETERED;
 }
 
-function getLimit(
-  chain: AnyChain,
-  ntt: NttTokenDef,
-  from?: number
-): Promise<NttRateLimit> {
-  if (chain instanceof SolanaChain) {
-    return getSolanaLimit(chain, ntt, from);
-  }
-  if (chain instanceof SuiChain) {
-    return getSuiLimit(chain, ntt, from);
-  }
-  return getEvmLimit(chain as EvmChain, ntt, from);
-}
+export class NttClient {
+  readonly chain: AnyChain;
+  protected asset: Asset;
 
-export async function getNttOutboundLimit(
-  chain: AnyChain,
-  asset: Asset
-): Promise<NttRateLimit> {
-  return getLimit(chain, NttRegistry.fromChain(chain, asset));
-}
+  constructor(chain: AnyChain, asset: Asset) {
+    this.chain = chain;
+    this.asset = asset;
+  }
 
-export async function getNttInboundLimit(
-  chain: AnyChain,
-  asset: Asset,
-  from: AnyChain
-): Promise<NttRateLimit> {
-  return getLimit(
-    chain,
-    NttRegistry.fromChain(chain, asset),
-    Wh.fromChain(from).getWormholeId()
-  );
+  getOutboundLimit(): Promise<NttRateLimit> {
+    return this.getLimit();
+  }
+
+  getInboundLimit(from: AnyChain): Promise<NttRateLimit> {
+    return this.getLimit(from);
+  }
+
+  private async getLimit(from?: AnyChain): Promise<NttRateLimit> {
+    const ntt = NttRegistry.fromChain(this.chain, this.asset);
+    const fromId = from && Wh.fromChain(from).getWormholeId();
+
+    if (this.chain instanceof SolanaChain) {
+      return getSolanaLimit(this.chain, ntt, fromId);
+    }
+    if (this.chain instanceof SuiChain) {
+      return getSuiLimit(this.chain, ntt, fromId);
+    }
+    return getEvmLimit(this.chain as AnyEvmChain, ntt, fromId);
+  }
 }

--- a/packages/xc-cfg/src/clients/index.ts
+++ b/packages/xc-cfg/src/clients/index.ts
@@ -1,2 +1,3 @@
 export * from './base';
+export * from './bridge';
 export * from './chain';

--- a/packages/xc-cfg/src/validations/bridge/index.ts
+++ b/packages/xc-cfg/src/validations/bridge/index.ts
@@ -1,0 +1,1 @@
+export * from './ntt';

--- a/packages/xc-cfg/src/validations/bridge/ntt.ts
+++ b/packages/xc-cfg/src/validations/bridge/ntt.ts
@@ -1,0 +1,86 @@
+import {
+  AnyChain,
+  Asset,
+  Ntt as NttRegistry,
+  TransferCtx,
+  TransferValidation,
+  TransferValidationError,
+} from '@galacticcouncil/xc-core';
+
+import { getNttInboundLimit, getNttOutboundLimit } from '../../clients';
+
+function unreachable(asset: Asset, chain: AnyChain): never {
+  throw new TransferValidationError('Ntt_Limit_Unreachable', {
+    asset: asset.originSymbol,
+    chain: chain.name,
+    error: 'ntt.limitUnreachable',
+  });
+}
+
+function rescale(amount: bigint, from: number, to: number): bigint {
+  if (from === to) {
+    return amount;
+  }
+  return to > from
+    ? amount * 10n ** BigInt(to - from)
+    : amount / 10n ** BigInt(from - to);
+}
+
+export class NttRateLimitValidation extends TransferValidation {
+  protected skipFor(ctx: TransferCtx): boolean {
+    const { asset, destination, source } = ctx;
+    return (
+      !NttRegistry.isKnown(source.chain, asset) ||
+      !NttRegistry.isKnown(destination.chain, destination.balance)
+    );
+  }
+
+  async validate(ctx: TransferCtx) {
+    if (this.skipFor(ctx)) {
+      return;
+    }
+
+    const { amount, asset, destination, source } = ctx;
+
+    const [outbound, inbound] = await Promise.all([
+      getNttOutboundLimit(source.chain, asset).catch(() =>
+        unreachable(asset, source.chain)
+      ),
+      getNttInboundLimit(
+        destination.chain,
+        destination.balance,
+        source.chain
+      ).catch(() => unreachable(destination.balance, destination.chain)),
+    ]);
+
+    if (outbound.windowMs > 0 && amount > outbound.capacity) {
+      throw new TransferValidationError('Ntt_Outbound_Limit_Exceeded', {
+        asset: asset.originSymbol,
+        chain: source.chain.name,
+        decimals: source.balance.decimals,
+        headroom: outbound.capacity,
+        limit: outbound.limit,
+        windowMs: outbound.windowMs,
+        error: 'ntt.outboundLimitExceeded',
+      });
+    }
+
+    const delivered = rescale(
+      amount,
+      source.balance.decimals,
+      destination.balance.decimals
+    );
+
+    if (inbound.windowMs > 0 && delivered > inbound.capacity) {
+      throw new TransferValidationError('Ntt_Inbound_Limit_Exceeded', {
+        asset: destination.balance.originSymbol,
+        chain: destination.chain.name,
+        decimals: destination.balance.decimals,
+        headroom: inbound.capacity,
+        limit: inbound.limit,
+        windowMs: inbound.windowMs,
+        error: 'ntt.inboundLimitExceeded',
+      });
+    }
+  }
+}

--- a/packages/xc-cfg/src/validations/bridge/ntt.ts
+++ b/packages/xc-cfg/src/validations/bridge/ntt.ts
@@ -6,8 +6,9 @@ import {
   TransferValidation,
   TransferValidationError,
 } from '@galacticcouncil/xc-core';
+import { big } from '@galacticcouncil/common';
 
-import { getNttInboundLimit, getNttOutboundLimit } from '../../clients';
+import { NttClient } from '../../clients';
 
 function unreachable(asset: Asset, chain: AnyChain): never {
   throw new TransferValidationError('Ntt_Limit_Unreachable', {
@@ -15,15 +16,6 @@ function unreachable(asset: Asset, chain: AnyChain): never {
     chain: chain.name,
     error: 'ntt.limitUnreachable',
   });
-}
-
-function rescale(amount: bigint, from: number, to: number): bigint {
-  if (from === to) {
-    return amount;
-  }
-  return to > from
-    ? amount * 10n ** BigInt(to - from)
-    : amount / 10n ** BigInt(from - to);
 }
 
 export class NttRateLimitValidation extends TransferValidation {
@@ -43,14 +35,12 @@ export class NttRateLimitValidation extends TransferValidation {
     const { amount, asset, destination, source } = ctx;
 
     const [outbound, inbound] = await Promise.all([
-      getNttOutboundLimit(source.chain, asset).catch(() =>
-        unreachable(asset, source.chain)
-      ),
-      getNttInboundLimit(
-        destination.chain,
-        destination.balance,
-        source.chain
-      ).catch(() => unreachable(destination.balance, destination.chain)),
+      new NttClient(source.chain, asset)
+        .getOutboundLimit()
+        .catch(() => unreachable(asset, source.chain)),
+      new NttClient(destination.chain, destination.balance)
+        .getInboundLimit(source.chain)
+        .catch(() => unreachable(destination.balance, destination.chain)),
     ]);
 
     if (outbound.windowMs > 0 && amount > outbound.capacity) {
@@ -65,7 +55,7 @@ export class NttRateLimitValidation extends TransferValidation {
       });
     }
 
-    const delivered = rescale(
+    const delivered = big.convertDecimals(
       amount,
       source.balance.decimals,
       destination.balance.decimals

--- a/packages/xc-cfg/src/validations/index.ts
+++ b/packages/xc-cfg/src/validations/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@galacticcouncil/xc-core';
 
 import { FeeValidation, DestFeeValidation } from './base';
+import { NttRateLimitValidation } from './bridge';
 import {
   HubEdValidation,
   HubFrozenValidation,
@@ -32,4 +33,5 @@ export const validations: TransferValidation[] = [
   new HydrationMrlFeeValidation(Matchers.isHydration, Matchers.isAny),
   new HydrationDepositLimitValidation(Matchers.isAny, Matchers.isHydration),
   new HydrationWithdrawLimitValidation(Matchers.isHydration, Matchers.isAny),
+  new NttRateLimitValidation(Matchers.isAny, Matchers.isAny),
 ];

--- a/packages/xc-core/src/evm/abi/NttManager.ts
+++ b/packages/xc-core/src/evm/abi/NttManager.ts
@@ -172,6 +172,117 @@ export const NTT_MANAGER = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'rateLimitDuration',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getCurrentOutboundCapacity',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint16',
+        name: 'chainId',
+        type: 'uint16',
+      },
+    ],
+    name: 'getCurrentInboundCapacity',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getOutboundLimitParams',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'TrimmedAmount',
+            name: 'limit',
+            type: 'uint72',
+          },
+          {
+            internalType: 'TrimmedAmount',
+            name: 'currentCapacity',
+            type: 'uint72',
+          },
+          {
+            internalType: 'uint64',
+            name: 'lastTxTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct IRateLimiter.RateLimitParams',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint16',
+        name: 'chainId',
+        type: 'uint16',
+      },
+    ],
+    name: 'getInboundLimitParams',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'TrimmedAmount',
+            name: 'limit',
+            type: 'uint72',
+          },
+          {
+            internalType: 'TrimmedAmount',
+            name: 'currentCapacity',
+            type: 'uint72',
+          },
+          {
+            internalType: 'uint64',
+            name: 'lastTxTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct IRateLimiter.RateLimitParams',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
   // `recipient` & `refundAddress` are indexed - they live in the topics,
   // not the data. Decoding them as plain fields silently shifts every
   // value by two (amount reads as the recipient, the chain id as amount).

--- a/packages/xc/docs/ntt.md
+++ b/packages/xc/docs/ntt.md
@@ -165,9 +165,10 @@ rate limiter that applies.** The Wormhole Governor governs Token Bridge emitters
 own transceiver, so no governor notional budget is consumed and Hydration isn't even a
 governed chain.
 
-Read via [getNttOutboundLimit / getNttInboundLimit](packages/xc-cfg/src/clients/bridge/ntt.ts)
-(`clients` export of xc-cfg) — `{ capacity, limit, capacityAtLastTx, lastTxMs, windowMs }`,
-amounts in token decimals:
+Read via [NttClient](packages/xc-cfg/src/clients/bridge/ntt.ts) (`clients` export of
+xc-cfg) — `new NttClient(chain, asset)`, then `getOutboundLimit()` /
+`getInboundLimit(from)` returning
+`{ capacity, limit, capacityAtLastTx, lastTxMs, windowMs }`, amounts in token decimals:
 
 | Platform | Source |
 | --- | --- |

--- a/packages/xc/docs/ntt.md
+++ b/packages/xc/docs/ntt.md
@@ -156,6 +156,62 @@ Sui specifics:
 - Fee is whatever the [SuiPlatform](packages/xc-sdk/src/platforms/sui/SuiPlatform.ts)
   dry run reports (computation + storage); the wormhole message fee is 0.
 
+## Rate limits
+
+Each manager meters volume per direction over a 24h window that refills linearly —
+outbound on the source, inbound per peer chain on the destination. **This is the only
+rate limiter that applies.** The Wormhole Governor governs Token Bridge emitters only
+(guardian `node/pkg/governor` matches `KnownTokenbridgeEmitters`), and NTT emits from its
+own transceiver, so no governor notional budget is consumed and Hydration isn't even a
+governed chain.
+
+Read via [getNttOutboundLimit / getNttInboundLimit](packages/xc-cfg/src/clients/bridge/ntt.ts)
+(`clients` export of xc-cfg) — `{ capacity, limit, capacityAtLastTx, lastTxMs, windowMs }`,
+amounts in token decimals:
+
+| Platform | Source |
+| --- | --- |
+| evm | `rateLimitDuration()`, `getCurrent{Out,In}boundCapacity()`, `get{Out,In}boundLimitParams()` |
+| solana | `outbox_rate_limit` / `inbox_rate_limit` pdas, refill computed locally |
+| sui | manager State `outbox.rate_limit` / `peers` table entry, ms timestamps |
+
+Upstream's `SolanaNtt.getCurrentOutboundCapacity()` returns `capacity_at_last_tx` — the
+stored value, **not** refilled — which is why the solana path decodes the account itself.
+The evm limit params are packed `TrimmedAmount`s (`amount << 8 | decimals`) and need
+untrimming to token decimals; the capacity getters already answer untrimmed.
+
+Configured values live in `ops/tokens/<token>/deployment.json` of the ntt repo, but
+on-chain is the truth — the solana limits have already been re-set since. The hub legs
+carry the real limits (Ethereum USDC/USDT/DAI/sUSDS 100k, WBTC 10, WETH 10k; Base EURC
+100k; Sui SUI 100k), Hydration is `uint64` max trimmed on both directions — the "opted
+out" sentinel, worth rendering as unlimited rather than as 184,467,440,737.
+
+`capacity` is nearly always at the limit and says little on its own: the bucket refills at
+`limit / windowMs`, which dwarfs real volume, so a transfer is paid back within
+`amount / (limit / window)`. `capacityAtLastTx` + `lastTxMs` are the only trace of recent
+volume a manager keeps. Note the **backflow** — sending consumes outbound and *refills*
+the destination's inbound by the same amount (and the reverse on redeem), so both buckets
+of a pair carry the same residual.
+
+[NttRateLimitValidation](packages/xc-cfg/src/validations/bridge/ntt.ts) checks both ends
+of a transfer. It gates on **both** sides being ntt-registered — the chain pair alone
+doesn't identify an ntt route, only the destination asset key does (`usdc_wh` for ntt vs
+`usdc_eth` for snowbridge over the same `usdc` source).
+
+The two directions fail very differently, which is why the destination is checked at all:
+
+- **outbound** — every builder sends with `shouldQueue = false`, so an over-limit transfer
+  just reverts (`NotEnoughCapacity` on evm). Nothing is committed; the check only turns a
+  wallet revert into a readable error.
+- **inbound** — no such flag exists. The source has already burned/locked, the delivery
+  sits in the destination queue for the window, and the recipient has to release it with
+  `completeInboundQueuedTransfer` — which is not reachable from transfer history yet (see
+  open items). No cancel.
+
+A limit that can't be read at all (rpc down) fails closed as `Ntt_Limit_Unreachable`,
+naming the side that failed — the inbound outcome is bad enough not to wave through a
+transfer whose headroom is unknown.
+
 ## Tracking & claim
 
 [WormholeTransfer](packages/xc-sdk/src/clients/WormholeTransfer.ts) queries wormholescan

--- a/scripts/changeset-snapshot.mjs
+++ b/scripts/changeset-snapshot.mjs
@@ -1,4 +1,5 @@
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
 
 import applyReleasePlan from '@changesets/apply-release-plan';
 import getReleasePlan from '@changesets/get-release-plan';
@@ -8,6 +9,45 @@ import { getPackages } from '@manypkg/get-packages';
 
 import { parseArgs } from './common.mjs';
 import { getUpgradeMessage } from './changeset-utils.mjs';
+
+const DEP_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+/**
+ * Snapshot versions are prereleases, and semver ranges (^2.2.0) never match a
+ * prerelease. Workspace packages depending on a bumped package are not part of
+ * the release plan, so they keep a range that no longer resolves, which drops
+ * the internal dependency edge from turbo's build graph and breaks build order.
+ * Pin those ranges to the exact snapshot version.
+ */
+const pinSnapshotDependents = (packages, releases) => {
+  const bumped = new Map(releases.map((r) => [r.name, r.newVersion]));
+
+  for (const pkg of packages.packages) {
+    const pkgJsonPath = path.join(pkg.dir, 'package.json');
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+
+    let changed = false;
+    for (const field of DEP_FIELDS) {
+      const deps = pkgJson[field];
+      if (!deps) continue;
+      for (const name of Object.keys(deps)) {
+        const version = bumped.get(name);
+        if (!version || deps[name] === version) continue;
+        deps[name] = version;
+        changed = true;
+        console.log(`Pinned ${pkgJson.name} ${field}.${name} -> ${version}`);
+      }
+    }
+    if (changed) {
+      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+    }
+  }
+};
 
 const main = async () => {
   const cwd = process.cwd();
@@ -60,6 +100,8 @@ const main = async () => {
   }
   console.log('Executing release plan...');
   await applyReleasePlan(releasePlan, packages, releaseConfig, true);
+
+  pinSnapshotDependents(packages, releasePlan.releases);
 };
 
 main()

--- a/scripts/changeset-snapshot.mjs
+++ b/scripts/changeset-snapshot.mjs
@@ -1,5 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
-import path from 'path';
+import { writeFileSync } from 'fs';
 
 import applyReleasePlan from '@changesets/apply-release-plan';
 import getReleasePlan from '@changesets/get-release-plan';
@@ -9,45 +8,6 @@ import { getPackages } from '@manypkg/get-packages';
 
 import { parseArgs } from './common.mjs';
 import { getUpgradeMessage } from './changeset-utils.mjs';
-
-const DEP_FIELDS = [
-  'dependencies',
-  'devDependencies',
-  'peerDependencies',
-  'optionalDependencies',
-];
-
-/**
- * Snapshot versions are prereleases, and semver ranges (^2.2.0) never match a
- * prerelease. Workspace packages depending on a bumped package are not part of
- * the release plan, so they keep a range that no longer resolves, which drops
- * the internal dependency edge from turbo's build graph and breaks build order.
- * Pin those ranges to the exact snapshot version.
- */
-const pinSnapshotDependents = (packages, releases) => {
-  const bumped = new Map(releases.map((r) => [r.name, r.newVersion]));
-
-  for (const pkg of packages.packages) {
-    const pkgJsonPath = path.join(pkg.dir, 'package.json');
-    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
-
-    let changed = false;
-    for (const field of DEP_FIELDS) {
-      const deps = pkgJson[field];
-      if (!deps) continue;
-      for (const name of Object.keys(deps)) {
-        const version = bumped.get(name);
-        if (!version || deps[name] === version) continue;
-        deps[name] = version;
-        changed = true;
-        console.log(`Pinned ${pkgJson.name} ${field}.${name} -> ${version}`);
-      }
-    }
-    if (changed) {
-      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
-    }
-  }
-};
 
 const main = async () => {
   const cwd = process.cwd();
@@ -100,8 +60,6 @@ const main = async () => {
   }
   console.log('Executing release plan...');
   await applyReleasePlan(releasePlan, packages, releaseConfig, true);
-
-  pinSnapshotDependents(packages, releasePlan.releases);
 };
 
 main()

--- a/scripts/changeset-snapshot.mjs
+++ b/scripts/changeset-snapshot.mjs
@@ -1,13 +1,15 @@
 import { writeFileSync } from 'fs';
+import path from 'path';
 
 import applyReleasePlan from '@changesets/apply-release-plan';
 import getReleasePlan from '@changesets/get-release-plan';
 
 import { read } from '@changesets/config';
+import * as git from '@changesets/git';
 import { getPackages } from '@manypkg/get-packages';
 
 import { parseArgs } from './common.mjs';
-import { getUpgradeMessage } from './changeset-utils.mjs';
+import { getReleaseMessage, getUpgradeMessage } from './changeset-utils.mjs';
 
 const main = async () => {
   const cwd = process.cwd();
@@ -59,9 +61,30 @@ const main = async () => {
     writeFileSync(output, releaseJson);
   }
   console.log('Executing release plan...');
-  await applyReleasePlan(releasePlan, packages, releaseConfig, true);
+  const touchedFiles = await applyReleasePlan(
+    releasePlan,
+    packages,
+    releaseConfig,
+    true
+  );
+
+  // Note, git gets angry if two git actions run at once, keep this sequential
+  for (const touchedFile of touchedFiles) {
+    await git.add(path.relative(cwd, touchedFile), cwd);
+  }
+
+  const releaseMessage = getReleaseMessage(releasePlan);
+  const committed = await git.commit(releaseMessage, cwd);
+  if (committed) {
+    console.log(releaseMessage);
+  } else {
+    throw new Error('Snapshot version bump could not be committed');
+  }
 };
 
 main()
   .then(() => console.log('Snapshot version bump done ✅'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });

--- a/scripts/changeset-snapshot.mjs
+++ b/scripts/changeset-snapshot.mjs
@@ -1,15 +1,13 @@
 import { writeFileSync } from 'fs';
-import path from 'path';
 
 import applyReleasePlan from '@changesets/apply-release-plan';
 import getReleasePlan from '@changesets/get-release-plan';
 
 import { read } from '@changesets/config';
-import * as git from '@changesets/git';
 import { getPackages } from '@manypkg/get-packages';
 
 import { parseArgs } from './common.mjs';
-import { getReleaseMessage, getUpgradeMessage } from './changeset-utils.mjs';
+import { getUpgradeMessage } from './changeset-utils.mjs';
 
 const main = async () => {
   const cwd = process.cwd();
@@ -61,30 +59,9 @@ const main = async () => {
     writeFileSync(output, releaseJson);
   }
   console.log('Executing release plan...');
-  const touchedFiles = await applyReleasePlan(
-    releasePlan,
-    packages,
-    releaseConfig,
-    true
-  );
-
-  // Note, git gets angry if two git actions run at once, keep this sequential
-  for (const touchedFile of touchedFiles) {
-    await git.add(path.relative(cwd, touchedFile), cwd);
-  }
-
-  const releaseMessage = getReleaseMessage(releasePlan);
-  const committed = await git.commit(releaseMessage, cwd);
-  if (committed) {
-    console.log(releaseMessage);
-  } else {
-    throw new Error('Snapshot version bump could not be committed');
-  }
+  await applyReleasePlan(releasePlan, packages, releaseConfig, true);
 };
 
 main()
   .then(() => console.log('Snapshot version bump done ✅'))
-  .catch((err) => {
-    console.error(err);
-    process.exitCode = 1;
-  });
+  .catch(console.error);


### PR DESCRIPTION
Reads the per-manager NTT rate limits on all three platforms and validates a transfer
against both ends before signing. Without this, an over-limit transfer either reverts in
the wallet with a bare `NotEnoughCapacity`, or — inbound — succeeds on the source and
then sits in the destination queue with no way to cancel.

Worth knowing up front, because it surprised me: **the manager's own 24h window is the
only rate limiter that touches NTT.** The Wormhole Governor governs Token Bridge emitters
only (guardian `node/pkg/governor` matches `KnownTokenbridgeEmitters`), NTT emits from its
own transceiver, and Hydration isn't a governed chain. So there's no notional budget in
play anywhere — just the buckets on each manager.

### What's here

- `xc-core` — five rate-limit getters added to the `NttManager` abi
- `xc-cfg/clients/bridge/ntt.ts` — `getNttOutboundLimit(chain, asset)` /
  `getNttInboundLimit(chain, asset, from)` → `{ capacity, limit, capacityAtLastTx,
  lastTxMs, windowMs }`, token decimals
- `xc-cfg/validations/bridge/ntt.ts` — `NttRateLimitValidation`, registered `isAny → isAny`
- `examples/xc-transfer` — circuit breaker page renders headroom per ntt route
- docs in `packages/xc/docs/ntt.md`
