### PR TITLE
Staking periods account for the 2s and ttl change to 1 hour

### DIFF
--- a/.changeset/sharp-signs-sit.md
+++ b/.changeset/sharp-signs-sit.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/sdk-next': patch
+---
+
+staking periods account for the 2s block-time switch and ttl change to 1 hour

--- a/packages/sdk-next/src/client/ChainParams.ts
+++ b/packages/sdk-next/src/client/ChainParams.ts
@@ -4,7 +4,7 @@ import { Papi } from '../api';
 import { BLOCK_TIME_TARGET } from '../consts';
 
 const BLOCK_TIME_SAMPLE = 100;
-const BLOCK_TIME_TTL = 60_000;
+const BLOCK_TIME_TTL = 60 * 60 * 1000;
 
 export class ChainParams extends Papi {
   private _minOrderBudget?: bigint;

--- a/packages/sdk-next/src/staking/StakingApi.ts
+++ b/packages/sdk-next/src/staking/StakingApi.ts
@@ -1,7 +1,6 @@
 import {
   calculate_accumulated_rps,
   calculate_percentage_amount,
-  calculate_period_number,
   calculate_points,
   calculate_rewards,
   sigmoid,
@@ -14,7 +13,7 @@ import { SYSTEM_ASSET_ID } from '../consts';
 import { Balance } from '../types';
 
 import { isConviction, CONVICTIONS, TVote } from './types';
-import { getAccountAddress } from './utils';
+import { calculatePeriodNumber, getAccountAddress } from './utils';
 
 import { StakingClient } from './StakingClient';
 
@@ -217,6 +216,7 @@ export class StakingApi {
       timePointsWeight,
       actionPointsWeight,
       sixBlockSince,
+      twoSecBlocksSince,
     ] = await Promise.all([
       this.getPotBalance(),
       this.client.getPeriodLength(),
@@ -225,6 +225,7 @@ export class StakingApi {
       this.client.getTimePointsWeight(),
       this.client.getActionPointsWeight(),
       this.client.getSixBlockSince(),
+      this.client.getTwoSecBlocksSince(),
     ]);
 
     const pendingRewards = Big(potBalance.transferable.toString()).minus(
@@ -240,17 +241,22 @@ export class StakingApi {
           )
         : accumulatedRewardPerStake.toString();
 
-    const currentPeriod = calculate_period_number(
-      periodLength.toString(),
-      blockNumber,
-      sixBlockSince
-    );
+    // TS port of the 4-arg runtime math — the published wasm
+    // `calculate_period_number` predates the 2s switch anchor and would
+    // count 2s blocks with 6s-era weight (periods accruing 3× too fast).
+    const currentPeriod = calculatePeriodNumber(
+      BigInt(periodLength),
+      BigInt(blockNumber),
+      BigInt(sixBlockSince),
+      BigInt(twoSecBlocksSince)
+    ).toString();
 
-    const enteredAt = calculate_period_number(
-      periodLength.toString(),
-      stakePosition.createdAt.toString(),
-      sixBlockSince
-    );
+    const enteredAt = calculatePeriodNumber(
+      BigInt(periodLength),
+      BigInt(stakePosition.createdAt),
+      BigInt(sixBlockSince),
+      BigInt(twoSecBlocksSince)
+    ).toString();
 
     const maxRewards = calculate_rewards(
       rewardPerStake,

--- a/packages/sdk-next/src/staking/StakingClient.ts
+++ b/packages/sdk-next/src/staking/StakingClient.ts
@@ -84,4 +84,26 @@ export class StakingClient extends Papi {
     const value = await query.getValue();
     return value.toString();
   }
+
+  /**
+   * `Parameters.TwoSecBlocksSince` — block of the 6s→2s switch, set once
+   * by the runtime migration (`u32::MAX` until then). Read via the unsafe
+   * api: the Parameters pallet is newer than the generated descriptors.
+   * Falls back to the sentinel on pre-2s runtimes, which reduces
+   * `calculatePeriodNumber` to the legacy 3-arg behaviour.
+   */
+  async getTwoSecBlocksSince(): Promise<string> {
+    const U32_MAX = '4294967295';
+    try {
+      const query = this.client.getUnsafeApi().query as unknown as {
+        Parameters: {
+          TwoSecBlocksSince: { getValue: () => Promise<number | undefined> };
+        };
+      };
+      const value = await query.Parameters.TwoSecBlocksSince.getValue();
+      return value === undefined ? U32_MAX : value.toString();
+    } catch {
+      return U32_MAX;
+    }
+  }
 }

--- a/packages/sdk-next/src/staking/utils.spec.ts
+++ b/packages/sdk-next/src/staking/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getAccountAddress } from './utils';
+import { calculatePeriodNumber, getAccountAddress } from './utils';
 
 describe('staking utils', () => {
   it('should return correct address from seed', async () => {
@@ -6,5 +6,46 @@ describe('staking utils', () => {
     expect(result).toStrictEqual(
       '7L53bUSxyzrEVzb8VaVtehMs5DpWZ8UyydQHRB3xDq6GwwtF'
     );
+  });
+});
+
+describe('calculatePeriodNumber', () => {
+  // Test vectors ported 1:1 from hydra-dx-math (2s branch)
+  // math/src/staking/tests.rs
+  const U32_MAX = 4294967295n;
+
+  describe('pre-2s eras (two-sec sentinel), matches legacy 3-arg math', () => {
+    it.each([
+      [1n, 12_341n, 12_341n, 12_341n],
+      [1_000n, 12_341n, 12_342n, 12n],
+      [1_000n, 1n, 1n, 0n],
+      [82n, 12_341n, 12_341n, 150n],
+      [41n, 12_341n, 5_001n, 211n],
+      [2_617n, 678_789_789n, 89_789_124n, 146_843n],
+    ])(
+      'periodLength %s, block %s, sixSince %s -> %s',
+      (periodLength, block, sixSince, expected) => {
+        expect(
+          calculatePeriodNumber(periodLength, block, sixSince, U32_MAX)
+        ).toBe(expected);
+      }
+    );
+  });
+
+  describe('after the two-sec transition', () => {
+    it.each([
+      [100n, 10n],
+      [200n, 15n],
+      [259n, 15n],
+      [260n, 16n],
+    ])('block %s -> period %s', (block, expected) => {
+      expect(calculatePeriodNumber(10n, block, 100n, 200n)).toBe(expected);
+    });
+  });
+
+  it('falls back to legacy math when the two-sec anchor is invalid', () => {
+    // twoSecBlocksSince <= sixSecBlocksSince -> 6s-era formula
+    expect(calculatePeriodNumber(10n, 300n, 100n, 100n)).toBe(20n);
+    expect(calculatePeriodNumber(10n, 300n, 100n, 50n)).toBe(20n);
   });
 });

--- a/packages/sdk-next/src/staking/utils.ts
+++ b/packages/sdk-next/src/staking/utils.ts
@@ -9,3 +9,44 @@ export function getAccountAddress(seed: string) {
   const nameHex = toHex(nameU8a);
   return AccountId(HYDRATION_SS58_PREFIX).dec(nameHex);
 }
+
+/**
+ * Staking period number for a block, exact TypeScript port of
+ * `hydra-dx-math::staking::calculate_period_number` (2s runtime, 4-arg).
+ *
+ * `PeriodLength` is 12s-denominated (7200 = 1 day). The pallet keeps
+ * "1 period = 1 wall-clock day" across block-time migrations by weighting
+ * blocks per era against two switch anchors:
+ *
+ * - `sixSecBlocksSince` — 12s→6s switch (`Staking.SixSecBlocksSince`)
+ * - `twoSecBlocksSince` — 6s→2s switch (`Parameters.TwoSecBlocksSince`,
+ *   `u32::MAX` sentinel until the runtime migration sets it)
+ *
+ * The published `math-staking` wasm still exposes only the 3-arg version;
+ * counting 2s blocks with it inflates period accrual 3× after the switch.
+ * Integer (floor) division throughout, matching the runtime.
+ */
+export function calculatePeriodNumber(
+  periodLength: bigint,
+  blockNumber: bigint,
+  sixSecBlocksSince: bigint,
+  twoSecBlocksSince: bigint
+): bigint {
+  if (blockNumber <= sixSecBlocksSince) {
+    return blockNumber / periodLength;
+  }
+
+  if (
+    blockNumber <= twoSecBlocksSince ||
+    twoSecBlocksSince <= sixSecBlocksSince
+  ) {
+    return (sixSecBlocksSince + blockNumber) / (periodLength * 2n);
+  }
+
+  const normalized =
+    sixSecBlocksSince * 6n +
+    (twoSecBlocksSince - sixSecBlocksSince) * 3n +
+    (blockNumber - twoSecBlocksSince);
+
+  return normalized / (periodLength * 6n);
+}


### PR DESCRIPTION
The published period math only knows the 12s to 6s transition, so on a
2s chain it counts elapsed time three times too fast. Positions clear
the unclaimable window early and report a payable percentage the chain
will not honour.

Periods are now derived from both block-time anchors, falling back to
the pre-switch behaviour until the runtime sets the second one - safe
to ship ahead of the upgrade.

Also widens the block-time cache window, which was re-probing far more
often than the value can actually change