### PR TITLE
Basejump ethereum route

### DIFF
--- a/.changeset/brave-chicken-pull.md
+++ b/.changeset/brave-chicken-pull.md
@@ -1,0 +1,6 @@
+---
+'@galacticcouncil/xc-core': patch
+'@galacticcouncil/xc-cfg': patch
+---
+
+Adding basejump ethereum route support

--- a/packages/xc-cfg/src/builders/contracts/Basejump.spec.ts
+++ b/packages/xc-cfg/src/builders/contracts/Basejump.spec.ts
@@ -1,20 +1,26 @@
-import { Abi, ContractConfigBuilderParams } from '@galacticcouncil/xc-core';
+import {
+  Abi,
+  ContractConfig,
+  ContractConfigBuilderParams,
+} from '@galacticcouncil/xc-core';
 import { h160 } from '@galacticcouncil/common';
 
-import { eurc } from '../../assets';
-import { base, hydration } from '../../chains';
+import { usdc } from '../../assets';
+import { ethereum, hydration } from '../../chains';
 
 import { Basejump } from './Basejump';
 
 const { H160 } = h160;
 
+const EMITTER = '0xa72e2bf29c840eb93adbb9ee1aa41580f01c9944';
+
 const buildCtx = (address: string) => {
   return {
     address,
     amount: 1000000n,
-    asset: eurc,
+    asset: usdc,
     sender: '0x71FeB8b2849101a6E62e3369eaAfDc6154CD0Bc0',
-    source: { chain: base },
+    source: { chain: ethereum },
     destination: { chain: hydration },
   } as ContractConfigBuilderParams;
 };
@@ -62,13 +68,17 @@ describe('Basejump contract builder', () => {
       );
     });
 
-    it('should produce correct contract config', async () => {
+    it('should call the ethereum emitter', async () => {
       const ctx = buildCtx('0x71FeB8b2849101a6E62e3369eaAfDc6154CD0Bc0');
       const [config] = await Basejump().bridgeViaWormhole().build(ctx);
 
-      expect(config.func).toBe('bridgeViaWormhole');
-      expect(config.module).toBe('Basejump');
-      expect(config.args).toHaveLength(3);
+      expect(config).toMatchObject({
+        address: EMITTER,
+        func: 'bridgeViaWormhole',
+        module: 'Basejump',
+        type: 'Evm',
+      } as ContractConfig);
+      expect(config.args).toHaveLength(4);
     });
 
     it('should pass asset address as first arg', async () => {
@@ -77,8 +87,18 @@ describe('Basejump contract builder', () => {
 
       // First arg is the asset ERC20 address on the source chain
       const assetArg = (config.args[0] as string).toLowerCase();
-      const expectedAssetId = base.getAssetId(eurc)?.toString().toLowerCase();
+      const expectedAssetId = ethereum
+        .getAssetId(usdc)
+        ?.toString()
+        .toLowerCase();
       expect(assetArg).toBe(expectedAssetId);
+    });
+
+    it('should send no data for a plain transfer', async () => {
+      const ctx = buildCtx('0x71FeB8b2849101a6E62e3369eaAfDc6154CD0Bc0');
+      const [config] = await Basejump().bridgeViaWormhole().build(ctx);
+
+      expect(config.args[3]).toBe('0x');
     });
   });
 
@@ -96,18 +116,20 @@ describe('Basejump contract builder', () => {
       expect(inputs[0].name).toBe('asset');
     });
 
-    it('bridgeViaWormhole should accept (address, uint256, bytes32)', () => {
+    it('bridgeViaWormhole should be payable & accept (address, uint256, bytes32, bytes)', () => {
       const abi = Abi.Basejump as readonly Record<string, unknown>[];
       const fn = abi.find(
         (e) => e.type === 'function' && e.name === 'bridgeViaWormhole'
       ) as Record<string, unknown> | undefined;
 
       expect(fn).toBeDefined();
+      expect(fn!.stateMutability).toBe('payable');
       const inputs = fn!.inputs as { type: string }[];
       expect(inputs.map((i) => i.type)).toEqual([
         'address',
         'uint256',
         'bytes32',
+        'bytes',
       ]);
     });
   });

--- a/packages/xc-cfg/src/builders/contracts/Basejump.ts
+++ b/packages/xc-cfg/src/builders/contracts/Basejump.ts
@@ -33,7 +33,7 @@ const bridgeViaWormhole = (): ContractConfigBuilder => ({
       new ContractConfig({
         abi: Abi.Basejump,
         address: ctxBj.getAddress(),
-        args: [parseAssetId(assetId), amount, toAccountId32(address)],
+        args: [parseAssetId(assetId), amount, toAccountId32(address), '0x'],
         func: 'bridgeViaWormhole',
         module: 'Basejump',
       }),

--- a/packages/xc-cfg/src/chains/evm/base.ts
+++ b/packages/xc-cfg/src/chains/evm/base.ts
@@ -36,9 +36,6 @@ export const base = new EvmChain({
   evmChain: evmChain,
   explorer: 'https://basescan.org/',
   rpcs: ['https://stylish-quick-firefly.base-mainnet.quiknode.pro/'],
-  basejump: {
-    address: '0xf5b9334e44f800382cb47fc19669401d694e529b',
-  },
   wormhole: {
     id: 30,
     coreBridge: '0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6',

--- a/packages/xc-cfg/src/chains/evm/mainnet.ts
+++ b/packages/xc-cfg/src/chains/evm/mainnet.ts
@@ -146,6 +146,9 @@ export const ethereum = new EvmChain({
     'https://ethereum-rpc.publicnode.com',
     'https://cosmopolitan-dimensional-diagram.quiknode.pro',
   ],
+  basejump: {
+    address: '0xa72e2bf29c840eb93adbb9ee1aa41580f01c9944',
+  },
   snowbridge: {
     id: 1,
     gateway: '0x27ca963c279c93801941e1eb8799c23f407d68e7',

--- a/packages/xc-cfg/src/configs/evm/base/index.ts
+++ b/packages/xc-cfg/src/configs/evm/base/index.ts
@@ -3,14 +3,9 @@ import { AssetRoute, ChainRoutes } from '@galacticcouncil/xc-core';
 import { eurc, eurc_wh } from '../../../assets';
 import { base } from '../../../chains';
 import {
-  toHydrationViaBasejumpTemplate,
   toHydrationViaNttExecutorTemplate,
   toHydrationViaNttTemplate,
 } from './templates';
-
-const toHydrationViaBasejump: AssetRoute[] = [
-  toHydrationViaBasejumpTemplate(eurc, eurc_wh),
-];
 
 const toHydrationViaNtt: AssetRoute[] = [
   toHydrationViaNttTemplate(eurc, eurc_wh),
@@ -22,9 +17,5 @@ const toHydrationViaNttExecutor: AssetRoute[] = [
 
 export const baseConfig = new ChainRoutes({
   chain: base,
-  routes: [
-    ...toHydrationViaNtt,
-    ...toHydrationViaNttExecutor,
-    ...toHydrationViaBasejump,
-  ],
+  routes: [...toHydrationViaNtt, ...toHydrationViaNttExecutor],
 });

--- a/packages/xc-cfg/src/configs/evm/base/templates.ts
+++ b/packages/xc-cfg/src/configs/evm/base/templates.ts
@@ -60,28 +60,3 @@ export function toHydrationViaNttExecutorTemplate(
     tags: [Tag.Wormhole, Tag.Ntt, Tag.NttExecutor],
   });
 }
-
-export function toHydrationViaBasejumpTemplate(
-  assetIn: Asset,
-  assetOut: Asset
-): AssetRoute {
-  return new AssetRoute({
-    source: {
-      asset: assetIn,
-      fee: {
-        asset: eth,
-      },
-      destinationFee: assetIn,
-    },
-    destination: {
-      chain: hydration,
-      asset: assetOut,
-      fee: {
-        amount: FeeAmountBuilder().Basejump().quoteFee(),
-        asset: assetIn,
-      },
-    },
-    contract: ContractBuilder().Basejump().bridgeViaWormhole(),
-    tags: [Tag.Basejump],
-  });
-}

--- a/packages/xc-cfg/src/configs/evm/ethereum/index.ts
+++ b/packages/xc-cfg/src/configs/evm/ethereum/index.ts
@@ -35,6 +35,7 @@ import { ContractBuilder, FeeAmountBuilder } from '../../../builders';
 import { Tag } from '../../../tags';
 
 import {
+  toHydrationViaBasejumpTemplate,
   toHydrationViaNttExecutorNativeTemplate,
   toHydrationViaNttExecutorTemplate,
   toHydrationViaNttTemplate,
@@ -60,6 +61,10 @@ const toHydrationViaNttExecutor: AssetRoute[] = [
   toHydrationViaNttExecutorTemplate(wbtc, wbtc_wh),
   toHydrationViaNttExecutorTemplate(weth, weth_wh),
   toHydrationViaNttExecutorNativeTemplate(eth, weth_wh),
+];
+
+const toHydrationViaBasejump: AssetRoute[] = [
+  toHydrationViaBasejumpTemplate(usdc, usdc_wh),
 ];
 
 const toHydrationViaSnowbridge: AssetRoute[] = [
@@ -146,6 +151,7 @@ export const ethereumConfig = new ChainRoutes({
   routes: [
     ...toHydrationViaNtt,
     ...toHydrationViaNttExecutor,
+    ...toHydrationViaBasejump,
     ...toHydrationViaSnowbridge,
     ...toHydrationViaSnowbridgeV1,
   ],

--- a/packages/xc-cfg/src/configs/evm/ethereum/templates.ts
+++ b/packages/xc-cfg/src/configs/evm/ethereum/templates.ts
@@ -152,3 +152,28 @@ export function toHydrationViaSnowbridgeV1Template(
     tags: [Tag.Snowbridge, Tag.SnowbridgeV1],
   });
 }
+
+export function toHydrationViaBasejumpTemplate(
+  assetIn: Asset,
+  assetOut: Asset
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: assetIn,
+      fee: {
+        asset: eth,
+      },
+      destinationFee: assetIn,
+    },
+    destination: {
+      chain: hydration,
+      asset: assetOut,
+      fee: {
+        amount: FeeAmountBuilder().Basejump().quoteFee(),
+        asset: assetIn,
+      },
+    },
+    contract: ContractBuilder().Basejump().bridgeViaWormhole(),
+    tags: [Tag.Basejump],
+  });
+}

--- a/packages/xc-cfg/src/configs/ntt.spec.ts
+++ b/packages/xc-cfg/src/configs/ntt.spec.ts
@@ -19,7 +19,7 @@ describe('ntt route configs', () => {
       ['hydration -> ethereum', hydrationConfig, usdc_wh, ethereum, usdc],
       ['hydration -> base', hydrationConfig, eurc_wh, base, eurc],
     ])('%s exposes both delivery models', (_, config, from, to, target) => {
-      // Other bridges can serve the same pair (base eurc is also Basejump),
+      // Other bridges can serve the same pair (ethereum usdc is also Basejump),
       // so narrow to ntt before splitting on the delivery model.
       const routes = config
         .getAssetDestinationRoutes(from, to)

--- a/packages/xc-core/src/evm/abi/Basejump.ts
+++ b/packages/xc-core/src/evm/abi/Basejump.ts
@@ -4,6 +4,7 @@ export const BASEJUMP = [
       { internalType: 'address', name: 'asset', type: 'address' },
       { internalType: 'uint256', name: 'amount', type: 'uint256' },
       { internalType: 'bytes32', name: 'recipient', type: 'bytes32' },
+      { internalType: 'bytes', name: 'data', type: 'bytes' },
     ],
     name: 'bridgeViaWormhole',
     outputs: [
@@ -14,17 +15,70 @@ export const BASEJUMP = [
     type: 'function',
   },
   {
-    inputs: [{ internalType: 'bytes', name: 'vaa', type: 'bytes' }],
-    name: 'completeTransfer',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
     inputs: [{ internalType: 'address', name: 'asset', type: 'address' }],
     name: 'quoteFee',
     outputs: [{ internalType: 'uint256', name: 'fee', type: 'uint256' }],
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'asset',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      { indexed: false, internalType: 'uint256', name: 'fee', type: 'uint256' },
+      {
+        indexed: false,
+        internalType: 'uint16',
+        name: 'destChain',
+        type: 'uint16',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'recipient',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'transferSequence',
+        type: 'uint64',
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'messageSequence',
+        type: 'uint64',
+      },
+    ],
+    name: 'BridgeInitiated',
+    type: 'event',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint256', name: 'fee', type: 'uint256' },
+    ],
+    name: 'AmountTooLowForFee',
+    type: 'error',
+  },
+  { inputs: [], name: 'LandingNotSet', type: 'error' },
+  {
+    inputs: [{ internalType: 'address', name: 'asset', type: 'address' }],
+    name: 'SettlementRouteNotSet',
+    type: 'error',
+  },
+  { inputs: [], name: 'ZeroAmount', type: 'error' },
+  { inputs: [], name: 'ZeroAmountReceived', type: 'error' },
 ] as const;


### PR DESCRIPTION
Moves Basejump from the Base EURC corridor to the Ethereum USDC corridor that whm deployed on 2026-08-28, and aligns the SDK with the v2 emitter.
