### PR TITLE
Adding robinhood ntts 

### DIFF
--- a/.changeset/puny-beds-lay.md
+++ b/.changeset/puny-beds-lay.md
@@ -1,0 +1,6 @@
+---
+'@galacticcouncil/xc-core': patch
+'@galacticcouncil/xc-cfg': patch
+---
+
+Adding robinhood chain support

--- a/examples/xc-transfer/src/balances.ts
+++ b/examples/xc-transfer/src/balances.ts
@@ -8,6 +8,7 @@ const CHAINS = [
   'assethub',
   'ethereum',
   'base',
+  'robinhood',
   'solana',
   'sui',
 ];

--- a/examples/xc-transfer/src/ntt.ts
+++ b/examples/xc-transfer/src/ntt.ts
@@ -21,7 +21,7 @@ const { Tag } = tags;
  *    once `claim` is run against the destination chain.
  *  - executor — the sender pays the Executor to redeem on the far side, so
  *    there is nothing to claim. Costs source native gas on top of the
- *    transfer (weth on hydration, eth on ethereum/base).
+ *    transfer (weth on hydration, eth on ethereum/base/robinhood).
  *
  * The executor routes carry both tags, so `Tag.NttExecutor` picks one
  * unambiguously. Plain `Tag.Ntt` resolves to whichever route the config
@@ -31,7 +31,6 @@ const { Tag } = tags;
 
 // Evm chains sign with the h160; hydration takes an ss58 (bound on chain,
 // see EnsureAddressTruncated) or the same h160.
-//
 // The two hydration routes are NOT equivalent for wormhole: an ss58 signs
 // one batched `EVM.call` extrinsic, whose logs are missing from the ethereum
 // view of some hydration rpcs - including the one the guardians read - so the
@@ -156,7 +155,7 @@ async function transfer({ source, route, executor }: NttRoute, amount: string) {
   }
 
   // The executor indexes whichever call emits RequestForExecution, and that
-  // is always the last one - the shim transfer on ethereum/base, the separate
+  // is always the last one - the shim transfer on evm chains, the separate
   // requestExecution on the hydration bypass. Everything ahead of it is a
   // wrap/approve prerequisite whose hash the executor knows nothing of.
   let txHash: string | undefined;

--- a/examples/xc-transfer/src/redeem.ts
+++ b/examples/xc-transfer/src/redeem.ts
@@ -20,6 +20,7 @@ const { config } = xc;
 
 const ethereum = config.getChain('ethereum') as EvmChain;
 const base = config.getChain('base') as EvmChain;
+const robinhood = config.getChain('robinhood') as EvmChain;
 const hydration = config.getChain('hydration') as EvmParachain;
 const solana = config.getChain('solana') as SolanaChain;
 const sui = config.getChain('sui') as SuiChain;
@@ -54,6 +55,8 @@ export const redeem = {
     new EvmClaim().redeem(address, vaa, nttOf(ethereum, asset)),
   base: (address: string, vaa: string, asset: string) =>
     new EvmClaim().redeem(address, vaa, nttOf(base, asset)),
+  robinhood: (address: string, vaa: string, asset: string) =>
+    new EvmClaim().redeem(address, vaa, nttOf(robinhood, asset)),
   hydra: (address: string, vaa: string, asset: string) =>
     new EvmClaim().redeem(address, vaa, nttOf(hydration, asset)),
   hydraSub: async (address: string, vaa: string, asset: string) => {

--- a/examples/xc-transfer/src/signers/index.ts
+++ b/examples/xc-transfer/src/signers/index.ts
@@ -52,7 +52,13 @@ export async function signEvm(
   const account = H160.fromAny(call.from);
 
   const wallet = client.getSigner(account);
-  await wallet.switchChain({ id: client.chain.id });
+  // A chain the wallet does not ship with (robinhood) rejects the switch
+  // until it is added; adding switches to it as well.
+  try {
+    await wallet.switchChain({ id: client.chain.id });
+  } catch {
+    await wallet.addChain({ chain: client.chain });
+  }
   await wallet.request({ method: 'eth_requestAccounts' });
 
   // Resolve once the tx is CONFIRMED so callers can `await` and chain txs

--- a/examples/xc-transfer/src/utils/vaa.ts
+++ b/examples/xc-transfer/src/utils/vaa.ts
@@ -14,9 +14,11 @@ import {
   SuiClaim,
 } from '@galacticcouncil/xc-sdk';
 
-import { chainToChainId, encoding } from '@wormhole-foundation/sdk-base';
-import { deserialize } from '@wormhole-foundation/sdk-definitions';
-import { register } from '@wormhole-foundation/sdk-definitions-ntt';
+import {
+  deserializeLayout,
+  encoding,
+  type Layout,
+} from '@wormhole-foundation/sdk-base';
 
 import { sign, signSolanaAll } from '../signers';
 import { xc } from '../setup';
@@ -26,9 +28,61 @@ import { getWormholeChainById } from './wh';
 
 const { EvmAddr } = addr;
 
-// The ntt payload layouts stopped registering on import in 7.2.0, they are
-// opt-in now - `deserialize` throws without this. Idempotent.
-register();
+const bytes32 = { binary: 'bytes', size: 32 } as const;
+const nttTransferVaaLayout = [
+  { name: 'version', binary: 'uint', size: 1 },
+  { name: 'guardianSet', binary: 'uint', size: 4 },
+  {
+    name: 'signatures',
+    binary: 'array',
+    lengthSize: 1,
+    layout: { binary: 'bytes', size: 66 },
+  },
+  { name: 'timestamp', binary: 'uint', size: 4 },
+  { name: 'nonce', binary: 'uint', size: 4 },
+  { name: 'emitterChain', binary: 'uint', size: 2 },
+  { name: 'emitterAddress', ...bytes32 },
+  { name: 'sequence', binary: 'uint', size: 8 },
+  { name: 'consistencyLevel', binary: 'uint', size: 1 },
+  {
+    name: 'prefix',
+    binary: 'bytes',
+    custom: Uint8Array.from([0x99, 0x45, 0xff, 0x10]),
+    omit: true,
+  },
+  { name: 'sourceNttManager', ...bytes32 },
+  { name: 'recipientNttManager', ...bytes32 },
+  {
+    name: 'nttManagerPayload',
+    binary: 'bytes',
+    lengthSize: 2,
+    layout: [
+      { name: 'id', ...bytes32 },
+      { name: 'sender', ...bytes32 },
+      {
+        name: 'payload',
+        binary: 'bytes',
+        lengthSize: 2,
+        layout: [
+          {
+            name: 'prefix',
+            binary: 'bytes',
+            custom: Uint8Array.from([0x99, 0x4e, 0x54, 0x54]),
+            omit: true,
+          },
+          { name: 'decimals', binary: 'uint', size: 1 },
+          { name: 'amount', binary: 'uint', size: 8 },
+          { name: 'sourceToken', ...bytes32 },
+          { name: 'recipientAddress', ...bytes32 },
+          { name: 'recipientChain', binary: 'uint', size: 2 },
+          // Optional trailer, 2 byte length prefixed when present.
+          { name: 'additionalPayload', binary: 'bytes' },
+        ],
+      },
+    ],
+  },
+  { name: 'transceiverPayload', binary: 'bytes', lengthSize: 2 },
+] as const satisfies Layout;
 
 export type NttClaim = {
   /** `chain/emitter/sequence`, rebuilt from the vaa header */
@@ -58,23 +112,30 @@ function asVaaId(input: string): string | undefined {
 /**
  * Whatever was pasted, as the base64 the claim apis take.
  *
- * Three things get pasted in practice: a wormholescan link, the bare vaa id
- * it ends with, or the signed bytes themselves - base64 as the guardians
- * issue them, or the 0x hex some explorers render.
+ * Four things get pasted in practice: a wormholescan link, the bare vaa id
+ * it ends with, the source transaction hash, or the signed bytes themselves
+ * - base64 as the guardians issue them, or the 0x hex some explorers render.
  */
 async function resolveVaa(input: string): Promise<string> {
   const trimmed = input.trim().replace(/\s+/g, '');
   if (!trimmed) {
-    throw new Error('Paste a vaa, or a wormholescan link to one');
+    throw new Error('Paste a vaa, a tx hash, or a wormholescan link');
   }
+
+  const { whScan } = xc.wormhole.transfer;
 
   const id = asVaaId(trimmed);
   if (id) {
-    const operation = await xc.wormhole.transfer.whScan.getOperation(id);
+    const operation = await whScan.getOperation(id);
     if (!operation.vaa) {
       throw new Error(id + ' has no signed vaa yet');
     }
     return operation.vaa.raw;
+  }
+
+  if (/^0x[0-9a-fA-F]{64}$/.test(trimmed)) {
+    const vaa = await whScan.getVaaByTxHash(trimmed);
+    return vaa.vaa;
   }
 
   if (/^(0x)?[0-9a-fA-F]+$/.test(trimmed) && trimmed.length > 200) {
@@ -122,7 +183,7 @@ function toDisplayAddress(chain: AnyChain, universal: string): string {
 export function readVaa(vaaRaw: string): NttClaim {
   let vaa;
   try {
-    vaa = deserialize('Ntt:WormholeTransfer', encoding.b64.decode(vaaRaw));
+    vaa = deserializeLayout(nttTransferVaaLayout, encoding.b64.decode(vaaRaw));
   } catch (e) {
     throw new Error(
       'Not a signed ntt transfer vaa - ' +
@@ -130,19 +191,18 @@ export function readVaa(vaaRaw: string): NttClaim {
     );
   }
 
-  const { recipientNttManager, nttManagerPayload } = vaa.payload;
-  const { recipientAddress, recipientChain, trimmedAmount } =
+  const { recipientNttManager, nttManagerPayload } = vaa;
+  const { recipientAddress, recipientChain, decimals, amount } =
     nttManagerPayload.payload;
 
-  const wormholeId = chainToChainId(recipientChain);
-  const chain = getWormholeChainById(wormholeId);
+  const chain = getWormholeChainById(recipientChain);
   if (!chain) {
     throw new Error(
-      'Vaa targets ' + recipientChain + ' (wormhole ' + wormholeId + '), not configured here'
+      'Vaa targets wormhole chain ' + recipientChain + ', not configured here'
     );
   }
 
-  const manager = recipientNttManager.toString();
+  const manager = encoding.hex.encode(recipientNttManager, true);
   const ntt = findNtt(chain, manager);
   if (!ntt) {
     throw new Error(
@@ -152,14 +212,17 @@ export function readVaa(vaaRaw: string): NttClaim {
 
   return {
     id: [
-      chainToChainId(vaa.emitterChain),
-      vaa.emitterAddress.toString().replace(/^0x/, ''),
+      vaa.emitterChain,
+      encoding.hex.encode(vaa.emitterAddress),
       vaa.sequence,
     ].join('/'),
     chain: chain,
     ntt: ntt,
-    recipient: toDisplayAddress(chain, recipientAddress.toString()),
-    amount: String(Number(trimmedAmount.amount) / 10 ** trimmedAmount.decimals),
+    recipient: toDisplayAddress(
+      chain,
+      encoding.hex.encode(recipientAddress, true)
+    ),
+    amount: String(Number(amount) / 10 ** decimals),
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "tsx": "^4.20.6",
         "turbo": "^2.5.8",
         "typescript": "^5.7.2",
-        "viem": "^2.38.3"
+        "viem": "^2.55.4"
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "0.25.0",
@@ -21145,7 +21145,7 @@
         "@galacticcouncil/descriptors": ">=2.0.0",
         "polkadot-api": "^2.1.7",
         "rxjs": "^7.8.0",
-        "viem": "^2.38.3"
+        "viem": "^2.55.4"
       }
     },
     "packages/xc-scan": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tsx": "^4.20.6",
     "turbo": "^2.5.8",
     "typescript": "^5.7.2",
-    "viem": "^2.38.3"
+    "viem": "^2.55.4"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "0.25.0",

--- a/packages/xc-cfg/src/assets.ts
+++ b/packages/xc-cfg/src/assets.ts
@@ -85,6 +85,11 @@ export const hdx = new Asset({
   originSymbol: 'HDX',
 });
 
+export const hollar = new Asset({
+  key: 'hollar',
+  originSymbol: 'HOLLAR',
+});
+
 export const ibtc = new Asset({
   key: 'ibtc',
   originSymbol: 'IBTC',
@@ -298,6 +303,7 @@ export const assets: Asset[] = [
   eth,
   glmr,
   hdx,
+  hollar,
   ibtc,
   intr,
   ksm,

--- a/packages/xc-cfg/src/chains/chains.spec.ts
+++ b/packages/xc-cfg/src/chains/chains.spec.ts
@@ -86,6 +86,7 @@ describe('chain address space', () => {
     'mythos',
     'ethereum',
     'base',
+    'robinhood',
     'solana',
     'sui',
   ];
@@ -100,6 +101,7 @@ describe('chain address space', () => {
       'mythos',
       'ethereum',
       'base',
+      'robinhood',
     ]);
   });
 
@@ -132,5 +134,6 @@ describe('chain address normalization', () => {
     );
     expect(chainsMap.get('ethereum')!.getNormalizedAddress(EVM)).toEqual(EVM);
     expect(chainsMap.get('base')!.getNormalizedAddress(EVM)).toEqual(EVM);
+    expect(chainsMap.get('robinhood')!.getNormalizedAddress(EVM)).toEqual(EVM);
   });
 });

--- a/packages/xc-cfg/src/chains/evm/index.ts
+++ b/packages/xc-cfg/src/chains/evm/index.ts
@@ -2,7 +2,8 @@ import { AnyChain } from '@galacticcouncil/xc-core';
 
 import { base } from './base';
 import { ethereum } from './mainnet';
+import { robinhood } from './robinhood';
 
-export const evmChains: AnyChain[] = [base, ethereum];
+export const evmChains: AnyChain[] = [base, ethereum, robinhood];
 
-export { base, ethereum };
+export { base, ethereum, robinhood };

--- a/packages/xc-cfg/src/chains/evm/robinhood.ts
+++ b/packages/xc-cfg/src/chains/evm/robinhood.ts
@@ -1,0 +1,81 @@
+import {
+  ChainEcosystem as Ecosystem,
+  EvmChain,
+  EvmBalanceType,
+} from '@galacticcouncil/xc-core';
+
+import { eth, hdx, hollar, weth } from '../../assets';
+import { robinhood as evmChain } from 'viem/chains';
+
+export const robinhood = new EvmChain({
+  id: 4663,
+  key: 'robinhood',
+  name: 'Robinhood',
+  assetsData: [
+    {
+      asset: eth,
+      decimals: 18,
+      id: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+    },
+    {
+      asset: weth,
+      decimals: 18,
+      id: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+    },
+    {
+      asset: hdx,
+      decimals: 12,
+      id: '0xb423C0B59C615793b0903668dc414e4fA3A64A33',
+    },
+    {
+      asset: hollar,
+      decimals: 18,
+      id: '0xD1dc3517732c98502b5c1ba2389AcA9E9016d89a',
+    },
+  ],
+  balance: EvmBalanceType.Erc20,
+  balanceOverrides: {
+    [eth.key]: EvmBalanceType.Native,
+  },
+  ecosystem: Ecosystem.Ethereum,
+  evmChain: evmChain,
+  explorer: 'https://robinhoodchain.blockscout.com/',
+  rpcs: ['https://rpc.mainnet.chain.robinhood.com'],
+  wormhole: {
+    id: 72,
+    coreBridge: '0x141fBa8AD5D61bdaB45A047cF60b5Ad9784987FB',
+    executor: '0xd19aAd5a69F7D35Cee169D9D90e1BbCB795ABB38',
+    nttExecutor: '0x0AdA5f1289Ee5EC07e397Ee86dB6bc861ce0A728',
+    ntt: {
+      // Burning managers - hydration is the hub.
+      [hdx.key]: {
+        token: '0xb423C0B59C615793b0903668dc414e4fA3A64A33',
+        manager: '0xf1a5fE4252D9a1C39b0Fb9DE1F19049ee57ED188',
+        transceiver: {
+          wormhole: '0x97Cd0d08c376005d09afcC47fa9ce0C384fbA406',
+        },
+      },
+      [hollar.key]: {
+        token: '0xD1dc3517732c98502b5c1ba2389AcA9E9016d89a',
+        manager: '0xE58D508743DD36368946D5A72A7dcD7cE960cE12',
+        transceiver: {
+          wormhole: '0x27afd50e83379a53458446E9d5F4a557B5f55c19',
+        },
+      },
+      [weth.key]: {
+        token: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+        manager: '0xB1A2ABCbC1FA276212f6eD239645161DeeA9861a',
+        transceiver: {
+          wormhole: '0x1352881a04cb9f9f5fB8442bc925e99EC15D3642',
+        },
+      },
+      [eth.key]: {
+        token: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+        manager: '0xB1A2ABCbC1FA276212f6eD239645161DeeA9861a',
+        transceiver: {
+          wormhole: '0x1352881a04cb9f9f5fB8442bc925e99EC15D3642',
+        },
+      },
+    },
+  },
+});

--- a/packages/xc-cfg/src/chains/polkadot/hydration.ts
+++ b/packages/xc-cfg/src/chains/polkadot/hydration.ts
@@ -1,5 +1,6 @@
 import {
   ChainEcosystem as Ecosystem,
+  EvmBalanceType,
   EvmParachain,
   SubstrateBalanceType,
 } from '@galacticcouncil/xc-core';
@@ -22,6 +23,7 @@ import {
   ewt,
   glmr,
   hdx,
+  hollar,
   ibtc,
   intr,
   jito_sol,
@@ -110,6 +112,7 @@ export const hydration = new EvmParachain({
   assetsData: [
     {
       asset: hdx,
+      decimals: 12,
       id: 0,
       xcmLocation: {
         parents: 0,
@@ -368,6 +371,26 @@ export const hydration = new EvmParachain({
             },
             {
               PalletInstance: 10,
+            },
+          ],
+        },
+      },
+    },
+    {
+      asset: hollar,
+      decimals: 18,
+      id: 222,
+      balanceId: '0x531a654d1696ED52e7275A8cede955E82620f99a',
+      min: 0.02,
+      xcmLocation: {
+        parents: 0,
+        interior: {
+          X1: [
+            {
+              AccountKey20: {
+                network: null,
+                key: '0x531a654d1696ed52e7275a8cede955e82620f99a',
+              },
             },
           ],
         },
@@ -1269,6 +1292,7 @@ export const hydration = new EvmParachain({
   balance: SubstrateBalanceType.Tokens,
   balanceOverrides: {
     [hdx.key]: SubstrateBalanceType.System,
+    [hollar.key]: EvmBalanceType.Erc20,
   },
   ecosystem: Ecosystem.Polkadot,
   evmChain: evmChain,
@@ -1286,6 +1310,7 @@ export const hydration = new EvmParachain({
     executor: '0xd633d8d1ceee8c8252196d44857c0f41b8dcb0d9',
     nttExecutor: '0xd3Dda7c8608Ea251C42c6E0A2A686aDc5e9C0C03',
     // Burning managers - token is the erc20 precompile of the asset id.
+    // Hub legs (hdx, hollar) lock instead.
     ntt: {
       [dai_wh.key]: {
         token: '0x0000000000000000000000000000000100000012',
@@ -1299,6 +1324,20 @@ export const hydration = new EvmParachain({
         manager: '0x8dd1286A29dF5a2785FB638d6fB1598144Cfbc4C',
         transceiver: {
           wormhole: '0x2e84fac378D67Dc2e11026fB4919E80263a87375',
+        },
+      },
+      [hdx.key]: {
+        token: '0x0000000000000000000000000000000100000000',
+        manager: '0x16Ac5B8d9078ed4cf5A522F907fd9dDb6C8841f1',
+        transceiver: {
+          wormhole: '0xdDE268D8B89834f6EF213002651D0586Ced646b9',
+        },
+      },
+      [hollar.key]: {
+        token: '0x531a654d1696ED52e7275A8cede955E82620f99a',
+        manager: '0x4188f147eec68921C1ee2d72898a263722a76844',
+        transceiver: {
+          wormhole: '0xE1d75C3c712BC61eBE892312F3455A67EC5D4799',
         },
       },
       [jito_sol.key]: {

--- a/packages/xc-cfg/src/clients/ntt/index.spec.ts
+++ b/packages/xc-cfg/src/clients/ntt/index.spec.ts
@@ -3,7 +3,14 @@ import { jest } from '@jest/globals';
 import { SolanaChain } from '@galacticcouncil/xc-core';
 
 import { sol } from '../../assets';
-import { base, ethereum, hydration, solana, sui_chain } from '../../chains';
+import {
+  base,
+  ethereum,
+  hydration,
+  robinhood,
+  solana,
+  sui_chain,
+} from '../../chains';
 
 import { nttClient } from './index';
 
@@ -31,6 +38,7 @@ describe('nttClient.getRedeemBudget', () => {
     it.each([
       ['ethereum', ethereum],
       ['base', base],
+      ['robinhood', robinhood],
       ['hydration', hydration],
     ])('should budget no value for %s', async (_, chain) => {
       const budget = await nttClient(chain).getRedeemBudget();

--- a/packages/xc-cfg/src/configs/evm/index.ts
+++ b/packages/xc-cfg/src/configs/evm/index.ts
@@ -2,5 +2,10 @@ import { ChainRoutes } from '@galacticcouncil/xc-core';
 
 import { baseConfig } from './base';
 import { ethereumConfig } from './ethereum';
+import { robinhoodConfig } from './robinhood';
 
-export const evmChainsConfig: ChainRoutes[] = [baseConfig, ethereumConfig];
+export const evmChainsConfig: ChainRoutes[] = [
+  baseConfig,
+  ethereumConfig,
+  robinhoodConfig,
+];

--- a/packages/xc-cfg/src/configs/evm/robinhood/index.ts
+++ b/packages/xc-cfg/src/configs/evm/robinhood/index.ts
@@ -1,0 +1,28 @@
+import { AssetRoute, ChainRoutes } from '@galacticcouncil/xc-core';
+
+import { eth, hdx, hollar, weth, weth_wh } from '../../../assets';
+import { robinhood } from '../../../chains';
+import {
+  toHydrationViaNttExecutorNativeTemplate,
+  toHydrationViaNttExecutorTemplate,
+  toHydrationViaNttTemplate,
+} from './templates';
+
+const toHydrationViaNtt: AssetRoute[] = [
+  toHydrationViaNttTemplate(hdx, hdx),
+  toHydrationViaNttTemplate(hollar, hollar),
+  toHydrationViaNttTemplate(weth, weth_wh),
+  toHydrationViaNttTemplate(eth, weth_wh),
+];
+
+const toHydrationViaNttExecutor: AssetRoute[] = [
+  toHydrationViaNttExecutorTemplate(hdx, hdx),
+  toHydrationViaNttExecutorTemplate(hollar, hollar),
+  toHydrationViaNttExecutorTemplate(weth, weth_wh),
+  toHydrationViaNttExecutorNativeTemplate(eth, weth_wh),
+];
+
+export const robinhoodConfig = new ChainRoutes({
+  chain: robinhood,
+  routes: [...toHydrationViaNtt, ...toHydrationViaNttExecutor],
+});

--- a/packages/xc-cfg/src/configs/evm/robinhood/templates.ts
+++ b/packages/xc-cfg/src/configs/evm/robinhood/templates.ts
@@ -1,0 +1,90 @@
+import { Asset, AssetRoute } from '@galacticcouncil/xc-core';
+
+import { eth } from '../../../assets';
+import { ContractBuilder, FeeAmountBuilder } from '../../../builders';
+import { hydration } from '../../../chains';
+import { Tag } from '../../../tags';
+
+export function toHydrationViaNttTemplate(
+  assetIn: Asset,
+  assetOut: Asset
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: assetIn,
+      fee: {
+        asset: eth,
+      },
+    },
+    destination: {
+      chain: hydration,
+      asset: assetOut,
+      fee: {
+        amount: 0,
+        asset: assetIn,
+      },
+    },
+    contract: ContractBuilder().Wormhole().Ntt().transfer(),
+    tags: [Tag.Wormhole, Tag.Ntt],
+  });
+}
+
+/**
+ * Executor-delivered variant, offered alongside the self-redeem route above
+ * for the same pair - the sender pays for delivery instead of signing a
+ * redeem on the destination. Cost is native gas on the source chain.
+ */
+export function toHydrationViaNttExecutorTemplate(
+  assetIn: Asset,
+  assetOut: Asset
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: assetIn,
+      fee: {
+        asset: eth,
+      },
+    },
+    destination: {
+      chain: hydration,
+      asset: assetOut,
+      fee: {
+        amount: FeeAmountBuilder().Wormhole().quoteExecutorCost(),
+        asset: eth,
+      },
+    },
+    contract: ContractBuilder().Wormhole().Ntt().transferWithExecutor(),
+    tags: [Tag.Wormhole, Tag.Ntt, Tag.NttExecutor],
+  });
+}
+
+/**
+ * Executor-delivered ntt out of a native gas source.
+ *
+ * The delivery price & executor cost come out of the very balance being
+ * bridged, so they are already folded into the source fee - declaring them
+ * as a destination fee too would charge the user twice.
+ */
+export function toHydrationViaNttExecutorNativeTemplate(
+  assetIn: Asset,
+  assetOut: Asset
+): AssetRoute {
+  return new AssetRoute({
+    source: {
+      asset: assetIn,
+      fee: {
+        asset: eth,
+      },
+    },
+    destination: {
+      chain: hydration,
+      asset: assetOut,
+      fee: {
+        amount: 0,
+        asset: assetIn,
+      },
+    },
+    contract: ContractBuilder().Wormhole().Ntt().transferWithExecutor(),
+    tags: [Tag.Wormhole, Tag.Ntt, Tag.NttExecutor],
+  });
+}

--- a/packages/xc-cfg/src/configs/ntt.spec.ts
+++ b/packages/xc-cfg/src/configs/ntt.spec.ts
@@ -1,11 +1,22 @@
 import { AssetRoute } from '@galacticcouncil/xc-core';
 
-import { eth, eurc, eurc_wh, usdc, usdc_wh, weth_wh } from '../assets';
-import { base, ethereum, hydration } from '../chains';
+import {
+  eth,
+  eurc,
+  eurc_wh,
+  hdx,
+  hollar,
+  weth,
+  usdc,
+  usdc_wh,
+  weth_wh,
+} from '../assets';
+import { base, ethereum, hydration, robinhood } from '../chains';
 import { Tag } from '../tags';
 
 import { baseConfig } from './evm/base';
 import { ethereumConfig } from './evm/ethereum';
+import { robinhoodConfig } from './evm/robinhood';
 import { hydrationConfig } from './polkadot/hydration';
 
 const isExecutor = (route: AssetRoute) => route.tags?.includes(Tag.NttExecutor);
@@ -16,8 +27,21 @@ describe('ntt route configs', () => {
       ['ethereum erc20', ethereumConfig, usdc, hydration, usdc_wh],
       ['ethereum native', ethereumConfig, eth, hydration, weth_wh],
       ['base erc20', baseConfig, eurc, hydration, eurc_wh],
+      ['robinhood hdx', robinhoodConfig, hdx, hydration, hdx],
+      ['robinhood hollar', robinhoodConfig, hollar, hydration, hollar],
+      ['robinhood erc20', robinhoodConfig, weth, hydration, weth_wh],
+      ['robinhood native', robinhoodConfig, eth, hydration, weth_wh],
       ['hydration -> ethereum', hydrationConfig, usdc_wh, ethereum, usdc],
       ['hydration -> base', hydrationConfig, eurc_wh, base, eurc],
+      ['hydration -> robinhood hdx', hydrationConfig, hdx, robinhood, hdx],
+      [
+        'hydration -> robinhood hollar',
+        hydrationConfig,
+        hollar,
+        robinhood,
+        hollar,
+      ],
+      ['hydration -> robinhood weth', hydrationConfig, weth_wh, robinhood, eth],
     ])('%s exposes both delivery models', (_, config, from, to, target) => {
       // Other bridges can serve the same pair (base eurc is also Basejump),
       // so narrow to ntt before splitting on the delivery model.
@@ -35,6 +59,7 @@ describe('ntt route configs', () => {
     const executorRoutes = [
       ...ethereumConfig.getRoutes(),
       ...baseConfig.getRoutes(),
+      ...robinhoodConfig.getRoutes(),
       ...hydrationConfig.getRoutes(),
     ].filter(isExecutor);
 
@@ -62,6 +87,7 @@ describe('ntt route configs', () => {
     it.each([
       ['ethereum', ethereumConfig, ethereum, eth],
       ['base', baseConfig, base, eth],
+      ['robinhood', robinhoodConfig, robinhood, eth],
       ['hydration', hydrationConfig, hydration, weth_wh],
     ])(
       'should charge %s gas in its evm native asset',

--- a/packages/xc-cfg/src/configs/polkadot/hydration/index.ts
+++ b/packages/xc-cfg/src/configs/polkadot/hydration/index.ts
@@ -20,6 +20,7 @@ import {
   ewt,
   glmr,
   hdx,
+  hollar,
   ibtc,
   intr,
   ksm,
@@ -64,6 +65,7 @@ import {
   mythos,
   neuroweb,
   pendulum,
+  robinhood,
   solana,
   sui_chain,
   unique,
@@ -253,6 +255,12 @@ const toEthereumViaNtt: AssetRoute[] = [
 
 const toBaseViaNtt: AssetRoute[] = [viaNttTemplate(eurc_wh, eurc, base)];
 
+const toRobinhoodViaNtt: AssetRoute[] = [
+  viaNttTemplate(hdx, hdx, robinhood),
+  viaNttTemplate(hollar, hollar, robinhood),
+  viaNttTemplate(weth_wh, eth, robinhood),
+];
+
 const toSolanaViaNtt: AssetRoute[] = [
   viaNttTemplate(sol, sol, solana),
   viaNttTemplate(jito_sol, jito_sol, solana),
@@ -270,6 +278,9 @@ const viaNttExecutor: AssetRoute[] = [
   viaNttExecutorTemplate(wbtc_wh, wbtc, ethereum),
   viaNttExecutorTemplate(weth_wh, eth, ethereum),
   viaNttExecutorTemplate(eurc_wh, eurc, base),
+  viaNttExecutorTemplate(hdx, hdx, robinhood),
+  viaNttExecutorTemplate(hollar, hollar, robinhood),
+  viaNttExecutorTemplate(weth_wh, eth, robinhood),
   viaNttExecutorTemplate(sol, wsol, solana),
   viaNttExecutorTemplate(jito_sol, jito_sol, solana),
   viaNttExecutorTemplate(prime, prime, solana),
@@ -333,6 +344,7 @@ export const hydrationConfig = new ChainRoutes({
     ...toBaseViaNtt,
     ...toEthereumViaNtt,
     ...toEthereumViaSnowbridge,
+    ...toRobinhoodViaNtt,
     ...toSolanaViaNtt,
     ...toSuiViaNtt,
     ...viaNttExecutor,

--- a/packages/xc-core/package.json
+++ b/packages/xc-core/package.json
@@ -56,6 +56,6 @@
     "@galacticcouncil/descriptors": ">=2.0.0",
     "polkadot-api": "^2.1.7",
     "rxjs": "^7.8.0",
-    "viem": "^2.38.3"
+    "viem": "^2.55.4"
   }
 }

--- a/packages/xc-core/src/chain/EvmParachain.ts
+++ b/packages/xc-core/src/chain/EvmParachain.ts
@@ -19,7 +19,7 @@ import { EvmClient, EvmResolver } from '../evm';
 import { addr } from '../utils';
 
 const { EvmAddr, Ss58Addr } = addr;
-const { H160 } = h160;
+const { H160, isEvmAccount } = h160;
 
 type EvmParachainBalanceType = SubstrateBalanceType | EvmBalanceType;
 
@@ -126,13 +126,23 @@ export class EvmParachain extends Parachain<EvmParachainBalanceType> {
   }
 
   /**
-   * EVM parachains key balances by the derived h160 account when the asset's
-   * balance id is an evm address, and by the normalized account otherwise.
+   * Account a balance is keyed by.
+   *
+   * - Substrate storages take the normalized account
+   * - Evm storages (a contract balance id) take the h160 the runtime reads
+   *   erc20 balances at: the bound address of an ETH\0 account, the truncated
+   *   public key of any other - bound or not, that is where its tokens sit
    */
   private async resolveAccount(asset: Asset, address: string): Promise<string> {
     const assetId = this.getBalanceAssetId(asset);
-    return EvmAddr.isValid(assetId.toString())
-      ? this.getDerivatedAddress(address)
-      : this.getNormalizedAddress(address);
+    if (!EvmAddr.isValid(assetId.toString())) {
+      return this.getNormalizedAddress(address);
+    }
+    if (EvmAddr.isValid(address)) {
+      return address;
+    }
+    return isEvmAccount(address)
+      ? H160.fromAccount(address)
+      : H160.fromSS58(address);
   }
 }


### PR DESCRIPTION
Summary
Adds Robinhood Chain (evm 4663, wormhole 72) as an NTT counterpart of Hydration and routes HDX, HOLLAR and WETH both ways, self-redeem and executor delivered. Hydration is the hub for HDX and HOLLAR: it locks the real asset, Robinhood mints a representation. WETH is the reverse, Robinhood locks canonical WETH as a second hub next to Ethereum and Hydration mints weth_wh.

Changes
xc-cfg

New robinhood chain: Wormhole core bridge, Executor, NttManagerWithExecutor, and the NTT managers from hydration-ntt/ops/tokens/{hdx,hollar,weth}. Balances read as ERC20 with native ETH.
Routes Robinhood → Hydration and Hydration → Robinhood for hdx, hollar, weth and native eth (wrapped upfront, shares the WETH deployment), each with a self-redeem and an executor variant, following the Base and Ethereum patterns.
New hollar asset. On Hydration it is asset 222 of type Erc20, so its balance is read from the contract (balanceId + EvmBalanceType.Erc20 override) rather than Tokens.
Hydration hdx gains decimals: 12; the NTT builder needs it to floor sub-8-decimal dust.
Specs extended for the new chain and pairs.
xc-core

EvmParachain.resolveAccount derives the account for EVM-keyed balances the way the runtime's evm_address does: bound h160 for ETH\0 accounts, truncated public key otherwise. The strict resolver used before throws for unbound substrate accounts, which would hide HOLLAR from most users. Transfers still go through the strict resolver.
viem peer bumped to ^2.55.4 (root dev dependency too), the first release that ships the robinhood chain definition.
examples/xc-transfer

Robinhood in the balances page and redeem.robinhood(...).
signEvm adds the chain to the wallet when a switch is rejected, since wallets don't ship Robinhood.
claim.vaa accepts a source tx hash, and decodes VAAs with a local layout that keeps chains as wormhole ids. The pinned wormhole sdk (6.1.4) predates chain 72 and its decoder rejects any VAA that touches Robinhood; 6.1.5 knows it, but the NTT packages peer on 6.1.4 exactly, so the bump is left for a follow-up.
